### PR TITLE
fix(installation): Unable to find gitlab gnome volume control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ docs/api/widgets
 !docs/api/widgets/index.rst
 
 .idea/*
+
+subprojects/gvc

--- a/meson.build
+++ b/meson.build
@@ -27,7 +27,7 @@ dependency('gio-2.0')
 dependency('gtk4')
 dependency('gtk4-layer-shell-0')
 
-# gvc
+#gvc
 subproject('gvc',
     default_options: [
         'package_name=' + meson.project_name(),
@@ -38,7 +38,6 @@ subproject('gvc',
         'alsa=false'
     ]
 )
-
 # Do installation
 install_subdir(
     'ignis',

--- a/subprojects/gvc.wrap
+++ b/subprojects/gvc.wrap
@@ -1,0 +1,3 @@
+[wrap-git]
+url = https://github.com/GNOME/libgnome-volume-control
+revision = master


### PR DESCRIPTION
Gnome Volume control repo on gitlab was not found, so the temporary solution is to use github repo