### PR TITLE
feat(nix): remove submodules for nix build

### DIFF
--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -15,7 +15,7 @@ Add Ignis to your flake's inputs:
 
 .. code-block:: nix
     
-    ignis.url = "git+https://github.com/linkfrg/ignis?submodules=1";
+    ignis.url = "github:linkfrg/ignis";
 
 Then add the following to ``environment.systemPackages`` or ``home.packages``:
 

--- a/nix/ignis.nix
+++ b/nix/ignis.nix
@@ -1,6 +1,14 @@
-{ pkgs, version ? "git", ... }:
+{ fetchFromGitLab, pkgs, version ? "git", ... }:
 let
   inherit (pkgs.lib) concatStringsSep;
+
+  gvc = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "GNOME";
+    repo = "libgnome-volume-control";
+    rev = "5f9768a2eac29c1ed56f1fbb449a77a3523683b6";
+    hash = "sha256-gdgTnxzH8BeYQAsvv++Yq/8wHi7ISk2LTBfU8hk12NM=";
+  };
 in
 pkgs.stdenv.mkDerivation {
   inherit version;
@@ -35,6 +43,8 @@ pkgs.stdenv.mkDerivation {
   ];
 
   patchPhase = ''
+    mkdir -p ./subprojects/gvc
+    cp -r ${gvc}/* ./subprojects/gvc
     substituteInPlace ignis/utils/sass.py \
       --replace-fail '/bin/sass' '${pkgs.dart-sass}/bin/sass'
   '';


### PR DESCRIPTION
By copying the submodule source during nix build,
remove the required submodule checkout introduced by https://github.com/linkfrg/ignis/pull/25.