### PR TITLE
fix(nix): prefix PATH instead of overwriting it

### DIFF
--- a/nix/ignis.nix
+++ b/nix/ignis.nix
@@ -59,7 +59,7 @@ pkgs.stdenv.mkDerivation {
   installPhase = ''
     ninja -C build install
     wrapProgram $out/bin/ignis \
-      --set PATH "${pkgs.gst_all_1.gstreamer}/bin:${pkgs.dart-sass}/bin:$PATH" \
+      --prefix-each PATH ":" "${pkgs.gst_all_1.gstreamer}/bin ${pkgs.dart-sass}/bin" \
       --set PYTHONPATH "${concatStringsSep ":" (map (pkg: "${pkg}/lib/python3.12/site-packages") [
         pkgs.python312Packages.markupsafe
         pkgs.python312Packages.pygobject3


### PR DESCRIPTION
Change the `wrapProgram` invocation to use `--prefix-each` instead of `--set` to allow inheriting the `PATH` environment variable from the system. This ensures `/run/current-system/sw/bin`, etc. are included in the PATH, allowing `Utils.exec_sh` to execute binaries installed on the system.

Fixes #70 