### PR TITLE
fix(nix): use librsvg pixbuf module loader cache to allow loading SVG icons

### DIFF
--- a/nix/ignis.nix
+++ b/nix/ignis.nix
@@ -85,7 +85,8 @@ pkgs.stdenv.mkDerivation {
         pkgs.gst_all_1.gst-plugins-bad
         pkgs.gst_all_1.gst-plugins-ugly
         pkgs.pipewire
-      ])}:$GST_PLUGIN_PATH"
+      ])}:$GST_PLUGIN_PATH" \
+      --set GDK_PIXBUF_MODULE_FILE "$(echo ${pkgs.librsvg.out}/lib/gdk-pixbuf-2.0/*/loaders.cache)"
   '';
 
   meta = with pkgs.lib; {


### PR DESCRIPTION
The default pixbuf module loader cache does not have any loader registered for SVG files and causes nearly all icon themes to stop working or have a tiny subset of their icons. This was fixed by using the loader cache provided by the librsvg package which contains an entry for SVG images pointing to its internal pixbuf loader.

Fixes #77 