### PR TITLE
feat(network): refactor signal handling

### DIFF
--- a/ignis/services/network/__init__.py
+++ b/ignis/services/network/__init__.py
@@ -2,7 +2,6 @@ from .access_point import WifiAccessPoint, ActiveAccessPoint
 from .ethernet_device import EthernetDevice
 from .ethernet import Ethernet
 from .service import NetworkService
-from .util import get_devices
 from .wifi_connect_dialog import WifiConnectDialog
 from .wifi_device import WifiDevice
 from .wifi import Wifi
@@ -16,7 +15,6 @@ __all__ = [
     "Ethernet",
     "NetworkService",
     "STATE",
-    "get_devices",
     "WifiConnectDialog",
     "WifiDevice",
     "Wifi",

--- a/ignis/services/network/access_point.py
+++ b/ignis/services/network/access_point.py
@@ -50,6 +50,12 @@ class WifiAccessPoint(IgnisGObject):
 
         return NM.utils_ssid_to_utf8(data)
 
+    @GObject.Signal
+    def removed(self):
+        """
+        Emitted when this access point is removed.
+        """
+
     @GObject.Property
     def point(self) -> NM.AccessPoint:
         """

--- a/ignis/services/network/ethernet.py
+++ b/ignis/services/network/ethernet.py
@@ -69,7 +69,7 @@ class Ethernet(IgnisGObject):
         if len(device.get_available_connections()) == 0:
             return
 
-        obj = EthernetDevice(device, self._client)
+        obj = EthernetDevice(device, self._client)  # type: ignore
         obj.connect(
             "notify::is-connected",
             lambda x, y: self.notify_list("is-connected", "icon-name"),

--- a/ignis/services/network/ethernet.py
+++ b/ignis/services/network/ethernet.py
@@ -26,7 +26,7 @@ class Ethernet(IgnisGObject):
         Emitted when a new Ethernet device is added.
 
         Args:
-            device (:class:`~ignis.services.network.WifiDevice`): An instance of the device.
+            device (:class:`~ignis.services.network.EthernetDevice`): An instance of the device.
         """
 
     @GObject.Property

--- a/ignis/services/network/ethernet.py
+++ b/ignis/services/network/ethernet.py
@@ -1,8 +1,7 @@
-from gi.repository import GObject, GLib  # type: ignore
+from gi.repository import GObject  # type: ignore
 from ignis.gobject import IgnisGObject
 from .ethernet_device import EthernetDevice
 from ._imports import NM
-from .util import get_devices
 
 
 class Ethernet(IgnisGObject):
@@ -13,12 +12,22 @@ class Ethernet(IgnisGObject):
     def __init__(self, client: NM.Client):
         super().__init__()
         self._client = client
-        self._devices: list[EthernetDevice] = []
-        self._client.connect(
-            "notify::all-devices",
-            lambda *args: GLib.timeout_add_seconds(1, self.__sync),
-        )
-        self.__sync()
+        self._devices: dict[NM.Device, EthernetDevice] = {}
+
+        self._client.connect("device-added", self.__add_device)
+        self._client.connect("device-removed", self.__remove_device)
+
+        for device in self._client.get_devices():
+            self.__add_device(None, device, False)
+
+    @GObject.Signal(arg_types=(EthernetDevice,))
+    def new_device(self, *args):
+        """
+        Emitted when a new Ethernet device is added.
+
+        Args:
+            device (:class:`~ignis.services.network.WifiDevice`): An instance of the device.
+        """
 
     @GObject.Property
     def devices(self) -> list[EthernetDevice]:
@@ -27,7 +36,7 @@ class Ethernet(IgnisGObject):
 
         A list of Ethernet devices.
         """
-        return self._devices
+        return list(self._devices.values())
 
     @GObject.Property
     def is_connected(self) -> bool:
@@ -53,20 +62,28 @@ class Ethernet(IgnisGObject):
         else:
             return "network-wired-disconnected-symbolic"
 
-    def __sync(self) -> None:
-        self._devices = []
-        for device in get_devices(self._client, NM.DeviceType.ETHERNET):
-            self.__add_device(device)  # type: ignore
+    def __add_device(self, client, device: NM.Device, emit: bool = True) -> None:
+        if device.get_device_type() != NM.DeviceType.ETHERNET:
+            return
 
-        self.notify_all()
-
-    def __add_device(self, device: NM.DeviceEthernet) -> None:
         if len(device.get_available_connections()) == 0:
             return
 
-        dev = EthernetDevice(device, self._client)
-        dev.connect(
+        obj = EthernetDevice(device, self._client)
+        obj.connect(
             "notify::is-connected",
             lambda x, y: self.notify_list("is-connected", "icon-name"),
         )
-        self._devices.append(dev)
+        self._devices[device] = obj
+
+        if emit:
+            self.emit("new-device", obj)
+            self.notify("devices")
+
+    def __remove_device(self, client, device: NM.DeviceEthernet) -> None:
+        if device.get_device_type() != NM.DeviceType.ETHERNET:
+            return
+
+        obj = self._devices.pop(device)
+        obj.emit("removed")
+        self.notify("devices")

--- a/ignis/services/network/ethernet_device.py
+++ b/ignis/services/network/ethernet_device.py
@@ -27,6 +27,12 @@ class EthernetDevice(IgnisGObject):
         self._device.connect("notify::active-connection", self.__update_is_connected)
         self.__update_is_connected()
 
+    @GObject.Signal
+    def removed(self):
+        """
+        Emitted when this Ethernet device is removed.
+        """
+
     @GObject.Property
     def carrier(self) -> bool:
         """

--- a/ignis/services/network/util.py
+++ b/ignis/services/network/util.py
@@ -1,15 +1,3 @@
-from collections.abc import Generator
-from ._imports import NM
-
-
-def get_devices(
-    client: NM.Client, device_type: NM.DeviceType
-) -> Generator[NM.Device, None, None]:
-    for d in client.get_devices():
-        if d.get_device_type() == device_type:
-            yield d
-
-
 def check_is_vpn(func):
     def wrapper(*args, **kwargs):
         connection = args[2]

--- a/ignis/services/network/util.py
+++ b/ignis/services/network/util.py
@@ -8,3 +8,11 @@ def get_devices(
     for d in client.get_devices():
         if d.get_device_type() == device_type:
             yield d
+
+def check_is_vpn(func):
+    def wrapper(*args, **kwargs):
+        connection = args[2]
+        if connection.get_connection_type() == "vpn" or connection.get_connection_type() == "wireguard":
+            func(*args, **kwargs)
+
+    return wrapper

--- a/ignis/services/network/util.py
+++ b/ignis/services/network/util.py
@@ -9,10 +9,14 @@ def get_devices(
         if d.get_device_type() == device_type:
             yield d
 
+
 def check_is_vpn(func):
     def wrapper(*args, **kwargs):
         connection = args[2]
-        if connection.get_connection_type() == "vpn" or connection.get_connection_type() == "wireguard":
+        if (
+            connection.get_connection_type() == "vpn"
+            or connection.get_connection_type() == "wireguard"
+        ):
             func(*args, **kwargs)
 
     return wrapper

--- a/ignis/services/network/vpn.py
+++ b/ignis/services/network/vpn.py
@@ -131,7 +131,7 @@ class Vpn(IgnisGObject):
         Emitted when a new VPN connection is added.
 
         Args:
-            connection (:class:`~ignis.services.network.WifiAccessPoint`): An instance of the VPN connection.
+            connection (:class:`~ignis.services.network.VpnConnection`): An instance of the VPN connection.
         """
 
     @GObject.Signal(arg_types=(VpnConnection,))
@@ -140,7 +140,7 @@ class Vpn(IgnisGObject):
         Emitted when a VPN connection is activated.
 
         Args:
-            connection (:class:`~ignis.services.network.WifiAccessPoint`): An instance of the newly activated VPN connection.
+            connection (:class:`~ignis.services.network.VpnConnection`): An instance of the newly activated VPN connection.
         """
 
     @GObject.Property

--- a/ignis/services/network/vpn.py
+++ b/ignis/services/network/vpn.py
@@ -107,10 +107,8 @@ class Vpn(IgnisGObject):
     def __init__(self, client: NM.Client):
         super().__init__()
         self._client = client
-        self._connections: dict[NM.Connection | NM.ActiveConnection, VpnConnection] = {}
-        self._active_connections: dict[
-            NM.Connection | NM.ActiveConnection, VpnConnection
-        ] = {}
+        self._connections: dict[NM.Connection, VpnConnection] = {}
+        self._active_connections: dict[NM.ActiveConnection, VpnConnection] = {}
 
         self._client.connect("active-connection-added", self.__add_active_connection)
         self._client.connect(

--- a/ignis/services/network/vpn.py
+++ b/ignis/services/network/vpn.py
@@ -117,11 +117,11 @@ class Vpn(IgnisGObject):
         self._client.connect("connection-added", self.__add_connection)
         self._client.connect("connection-removed", self.__remove_connection)
 
-        for i in self._client.get_connections():  # type: ignore
-            self.__add_connection(None, i, False)  # type: ignore
+        for i in self._client.get_connections():
+            self.__add_connection(None, i, False)
 
-        for i in self._client.get_active_connections():  # type: ignore
-            self.__add_active_connection(None, i, False)  # type: ignore
+        for a in self._client.get_active_connections():
+            self.__add_active_connection(None, a, False)
 
     @GObject.Signal(arg_types=(VpnConnection,))
     def new_connection(self, *args):

--- a/ignis/services/network/vpn.py
+++ b/ignis/services/network/vpn.py
@@ -1,5 +1,6 @@
 from gi.repository import GObject  # type: ignore
 from ignis.gobject import IgnisGObject
+from typing import Union
 from ._imports import NM
 from .util import check_is_vpn
 
@@ -9,7 +10,9 @@ class VpnConnection(IgnisGObject):
     A VPN connection.
     """
 
-    def __init__(self, connection: NM.Connection | NM.ActiveConnection, client: NM.Client):
+    def __init__(
+        self, connection: Union[NM.Connection, NM.ActiveConnection], client: NM.Client
+    ):
         super().__init__()
         self._connection = connection
         self._client = client
@@ -105,7 +108,9 @@ class Vpn(IgnisGObject):
         super().__init__()
         self._client = client
         self._connections: dict[NM.Connection | NM.ActiveConnection, VpnConnection] = {}
-        self._active_connections: dict[NM.Connection | NM.ActiveConnection, VpnConnection] = {}
+        self._active_connections: dict[
+            NM.Connection | NM.ActiveConnection, VpnConnection
+        ] = {}
 
         self._client.connect("active-connection-added", self.__add_active_connection)
         self._client.connect(
@@ -117,7 +122,7 @@ class Vpn(IgnisGObject):
         for i in self._client.get_connections():  # type: ignore
             self.__add_connection(None, i, False)  # type: ignore
 
-        for i in self._client.get_active_connections():   # type: ignore
+        for i in self._client.get_active_connections():  # type: ignore
             self.__add_active_connection(None, i, False)  # type: ignore
 
     @GObject.Signal(arg_types=(VpnConnection,))

--- a/ignis/services/network/wifi.py
+++ b/ignis/services/network/wifi.py
@@ -88,7 +88,7 @@ class Wifi(IgnisGObject):
         if device.get_device_type() != NM.DeviceType.WIFI:
             return
 
-        obj = WifiDevice(device, self._client)
+        obj = WifiDevice(device, self._client)  # type: ignore
         obj.ap.connect(
             "notify::icon-name",
             lambda x, y: self.notify("icon-name"),

--- a/ignis/services/network/wifi_device.py
+++ b/ignis/services/network/wifi_device.py
@@ -99,7 +99,9 @@ class WifiDevice(IgnisGObject):
 
         self._device.request_scan_async(None, finish)
 
-    def __add_access_point(self, device, access_point: NM.AccessPoint, emit: bool = True) -> None:
+    def __add_access_point(
+        self, device, access_point: NM.AccessPoint, emit: bool = True
+    ) -> None:
         obj = WifiAccessPoint(access_point, self._client, self._device)
         self._access_points[access_point] = obj
 

--- a/ignis/services/network/wifi_device.py
+++ b/ignis/services/network/wifi_device.py
@@ -14,7 +14,7 @@ class WifiDevice(IgnisGObject):
         super().__init__()
         self._device = device
         self._client = client
-        self._access_points: list[WifiAccessPoint] = []
+        self._access_points: dict[NM.AccessPoint, WifiAccessPoint] = {}
 
         self._client.connect(
             "notify::wireless-enabled", lambda *args: self.notify_all()
@@ -22,14 +22,31 @@ class WifiDevice(IgnisGObject):
 
         self._ap: ActiveAccessPoint = ActiveAccessPoint(self._device, self._client)
 
-        self._device.connect("access-point-added", self.__sync_access_points)
-        self._device.connect("access-point-removed", self.__sync_access_points)
+        self._device.connect("access-point-added", self.__add_access_point)
+        self._device.connect("access-point-removed", self.__remove_access_point)
+
         self._device.connect("notify::state", lambda x, y: self.notify("state"))
         self._device.connect(
             "notify::active-connection", lambda x, y: self.notify("is-connected")
         )
 
-        self.__sync_access_points()
+        for i in self._device.get_access_points():
+            self.__add_access_point(None, i, False)
+
+    @GObject.Signal
+    def removed(self):
+        """
+        Emitted when this Wi-Fi device is removed.
+        """
+
+    @GObject.Signal(arg_types=(WifiAccessPoint,))
+    def new_access_point(self, *args):
+        """
+        Emitted when a new access point is added.
+
+        Args:
+            access_point (:class:`~ignis.services.network.WifiAccessPoint`): An instance of the access point.
+        """
 
     @GObject.Property
     def access_points(self) -> list[WifiAccessPoint]:
@@ -38,7 +55,7 @@ class WifiDevice(IgnisGObject):
 
         A list of access points (Wi-FI networks).
         """
-        return self._access_points
+        return list(self._access_points.values())
 
     @GObject.Property
     def ap(self) -> WifiAccessPoint:
@@ -82,9 +99,15 @@ class WifiDevice(IgnisGObject):
 
         self._device.request_scan_async(None, finish)
 
-    def __sync_access_points(self, *args) -> None:
-        self._access_points = [
-            WifiAccessPoint(point, self._client, self._device)
-            for point in self._device.get_access_points()
-        ]
-        self.notify("access_points")
+    def __add_access_point(self, device, access_point: NM.AccessPoint, emit: bool = True) -> None:
+        obj = WifiAccessPoint(access_point, self._client, self._device)
+        self._access_points[access_point] = obj
+
+        if emit:
+            self.emit("new-access-point", obj)
+            self.notify("access-points")
+
+    def __remove_access_point(self, device, access_point: NM.AccessPoint) -> None:
+        obj = self._access_points.pop(access_point)
+        obj.emit("removed")
+        self.notify("access-points")

--- a/stubs/gi/repository/NM.pyi
+++ b/stubs/gi/repository/NM.pyi
@@ -13535,7 +13535,7 @@ class SriovEswitchMode(enum.Enum):
     PRESERVE = -1
     SWITCHDEV = 1
 
-class SriovVFVlanProtocol(enum.Enum): ...
+class SriovVFVlanProtocol: ...
 
 class State(enum.Enum):
     ASLEEP = 10


### PR DESCRIPTION
This PR refactors signals handling in the Network Service.

Now components of the Network Service rely on such signals like ``device-added`` / ``device-removed`` (NM.Client) and etc.

It makes code easier and less shitty.

But the main goal is to provide new signals, you can find them in the code with descriptions in docstrings.

Closes: #50