### PR TITLE
Add bind_many and hyprland urgent workspaces

### DIFF
--- a/examples/bar/config.py
+++ b/examples/bar/config.py
@@ -30,6 +30,8 @@ def hyprland_workspace_button(workspace: dict) -> Widget.Button:
     )
     if workspace["id"] == hyprland.active_workspace["id"]:
         widget.add_css_class("active")
+    if workspace["id"] in hyprland.urgent_workspaces:
+        widget.add_css_class("urgent")
 
     return widget
 
@@ -96,9 +98,9 @@ def hyprland_workspaces() -> Widget.EventBox:
         on_scroll_down=lambda x: scroll_workspaces("down"),
         css_classes=["workspaces"],
         spacing=5,
-        child=hyprland.bind(
-            "workspaces",
-            transform=lambda value: [workspace_button(i) for i in value],
+        child=hyprland.bind_many(
+            ["workspaces", "urgent_workspaces"],
+            transform=lambda value, _: [workspace_button(i) for i in value],
         ),
     )
 

--- a/examples/bar/style.scss
+++ b/examples/bar/style.scss
@@ -8,6 +8,7 @@ $bg-light: #261d1e;
 $fg: #f0dedf;
 $active: #ffb2bc;
 $unactive: #d7c1c3;
+$urgent: #eb6f92;
 
 .bar {
     padding: 0.4rem 1rem;
@@ -51,6 +52,11 @@ $unactive: #d7c1c3;
 
 .workspace.active {
     background-color: $active;
+    color: $bg;
+}
+
+.workspace.urgent {
+    background-color: $urgent;
     color: $bg;
 }
 

--- a/ignis/gobject.py
+++ b/ignis/gobject.py
@@ -10,11 +10,11 @@ class Binding(GObject.Object):
     def __init__(
         self,
         target: GObject.Object,
-        target_property: str,
+        target_properties: list[str],
         transform: Callable | None = None,
     ):
         self._target = target
-        self._target_property = target_property
+        self._target_properties = target_properties
         self._transform = transform
         super().__init__()
 
@@ -28,13 +28,13 @@ class Binding(GObject.Object):
         return self._target
 
     @GObject.Property
-    def target_property(self) -> str:
+    def target_properties(self) -> list[str]:
         """
         - required, read-only
 
-        The property on the target GObject.
+        The properties on the target GObject to bind.
         """
-        return self._target_property
+        return self._target_properties
 
     @GObject.Property
     def transform(self) -> Callable | None:
@@ -106,7 +106,7 @@ class IgnisGObject(GObject.Object):
             self.bind_property2(
                 source_property=property_name,
                 target=value.target,
-                target_property=value.target_property,
+                target_properties=value.target_properties,
                 transform=value.transform,
             )
         else:
@@ -116,26 +116,34 @@ class IgnisGObject(GObject.Object):
         self,
         source_property: str,
         target: GObject.Object,
-        target_property: str,
+        target_properties: list[str],
         transform: Callable | None = None,
     ) -> None:
         """
-        Bind ``source_property`` on ``self`` with ``target_property`` on ``target``.
+        Bind ``source_property`` on ``self`` with ``target_properties`` on ``target``.
 
         Args:
             source_property: The property on ``self`` to bind.
             target: the target ``GObject.Object``.
-            target_property: the property on ``target`` to bind.
+            target_properties: the properties on ``target`` to bind.
             transform: The function that accepts a new property value and returns the processed value.
         """
 
         def callback(*args):
-            value = target.get_property(target_property.replace("-", "_"))
+            values = []
+            for target_property in target_properties:
+                values.append(target.get_property(target_property.replace("-", "_")))
+
             if transform:
-                value = transform(value)
+                value = transform(*values)
+            else:
+                if len(values) != 1:
+                    raise IndexError("No transform function on muliple binding")
+                value = values[0]
             self.set_property(source_property, value)
 
-        target.connect(f"notify::{target_property.replace('_', '-')}", callback)
+        for target_property in target_properties:
+            target.connect(f"notify::{target_property.replace('_', '-')}", callback)
         callback()
 
     def bind(self, property_name: str, transform: Callable | None = None) -> Binding:
@@ -148,7 +156,19 @@ class IgnisGObject(GObject.Object):
         Returns:
             :class:`~ignis.gobject.Binding`
         """
-        return Binding(self, property_name, transform)
+        return Binding(self, [property_name], transform)
+
+    def bind_many(self, property_names: list[str], transform: Callable) -> Binding:
+        """
+        Creates ``Binding`` from property name on ``self``.
+
+        Args:
+            property_names: List of property names of ``self``.
+            transform: The function that accepts a new property value and returns the processed value.
+        Returns:
+            :class:`~ignis.gobject.Binding`
+        """
+        return Binding(self, property_names, transform)
 
     def __getattribute__(self, name: str) -> Any:
         # This modified __getattribute__ method redirect all "set_" methods to set_property method to provive bindings support.

--- a/ignis/services/hyprland/service.py
+++ b/ignis/services/hyprland/service.py
@@ -204,9 +204,10 @@ class HyprlandService(BaseService):
 
     def __sync_active_window(self) -> None:
         self._active_window = json.loads(self.send_command("j/activewindow"))
-        active_window_id = self._active_window["address"][len("0x"):]
-        if active_window_id in self._urgent_windows:
-            self._urgent_windows.remove(active_window_id)
+        if self._active_window:
+            active_window_id = self._active_window["address"][len("0x"):]
+            if active_window_id in self._urgent_windows:
+                self._urgent_windows.remove(active_window_id)
         self.notify("active_window")
         self.notify("urgent_windows")
         self.notify("urgent_workspaces")


### PR DESCRIPTION
Add bind_many: allows a property to be bound to many properties of the same gobject easily through the use of transform.

Add Hyprland urgent workspaces and windows: keeps track of urgent hyprland workspaces and windows after launch.