### PR TITLE
feat: add `Widget.Stack` (`Widget.StackPage`, `Widget.StackSwitcher`)

### DIFF
--- a/docs/api/widgets/Stack.rst
+++ b/docs/api/widgets/Stack.rst
@@ -1,0 +1,11 @@
+Stack
+=======
+
+.. autoclass:: ignis.widgets.Widget.Stack
+    :members:
+
+.. autoclass:: ignis.widgets.Widget.StackPage
+    :members:
+
+.. autoclass:: ignis.widgets.Widget.StackSwitcher
+    :members:

--- a/ignis/widgets/__init__.py
+++ b/ignis/widgets/__init__.py
@@ -32,6 +32,9 @@ from .overlay import Overlay
 from .arrow import Arrow
 from .arrow_button import ArrowButton
 from .revealer_window import RevealerWindow
+from .stack import Stack
+from .stack_switcher import StackSwitcher
+from .stack_page import StackPage
 
 
 class Widget:
@@ -68,3 +71,6 @@ class Widget:
     Arrow: TypeAlias = Arrow
     ArrowButton: TypeAlias = ArrowButton
     RevealerWindow: TypeAlias = RevealerWindow
+    Stack: TypeAlias = Stack
+    StackSwitcher: TypeAlias = StackSwitcher
+    StackPage = StackPage

--- a/ignis/widgets/stack.py
+++ b/ignis/widgets/stack.py
@@ -39,11 +39,12 @@ class Stack(Gtk.Stack, BaseWidget):
             child=[Widget.StackSwitcher(stack=stack), stack],
         )
     """
+
     __gtype_name__ = "IgnisStack"
     __gproperties__ = {**BaseWidget.gproperties}
 
     def __init__(self, **kwargs):
-        Gtk.Label.__init__(self)
+        Gtk.Stack.__init__(self)
         self.override_enum("transition_type", Gtk.StackTransitionType)
         self._child: list[StackPage] = []
         BaseWidget.__init__(self, **kwargs)

--- a/ignis/widgets/stack.py
+++ b/ignis/widgets/stack.py
@@ -1,0 +1,66 @@
+from gi.repository import Gtk, GObject  # type: ignore
+from ignis.base_widget import BaseWidget
+from .stack_page import StackPage
+
+
+class Stack(Gtk.Stack, BaseWidget):
+    """
+    Bases: :class:`Gtk.Stack`
+
+    Stack is a container which only shows one of its children at a time.
+
+    It does not provide a means for users to change the visible child.
+    Instead, a separate widget such as :class:`~ignis.widgets.Widget.StackSwitcher` can be used with Stack to provide this functionality.
+
+    Overrided properties:
+        - transition_type: The type of animation used to transition between pages. Available values: :class:`Gtk.StackTransitionType`.
+
+    .. code-block:: python
+
+        from ignis.widgets import Widget
+
+        stack = Widget.Stack(
+            child=[
+                Widget.StackPage(
+                    title="page 1", child=Widget.Label(label="welcome to page 1!")
+                ),
+                Widget.StackPage(
+                    title="page 2", child=Widget.Label(label="welcome to page 2!")
+                ),
+                Widget.StackPage(
+                    title="page 3", child=Widget.Label(label="welcome to page 3!")
+                ),
+            ]
+        )
+
+        Widget.Box(
+            vertical=True,
+            # you should add both StackSwitcher and Stack.
+            child=[Widget.StackSwitcher(stack=stack), stack],
+        )
+    """
+    __gtype_name__ = "IgnisStack"
+    __gproperties__ = {**BaseWidget.gproperties}
+
+    def __init__(self, **kwargs):
+        Gtk.Label.__init__(self)
+        self.override_enum("transition_type", Gtk.StackTransitionType)
+        self._child: list[StackPage] = []
+        BaseWidget.__init__(self, **kwargs)
+
+    @GObject.Property
+    def child(self) -> list[StackPage]:
+        """
+        - optional, read-write
+
+        A list of pages.
+        """
+        return self._child
+
+    @child.setter
+    def child(self, value: list[StackPage]) -> None:
+        for i in self._child:
+            self.remove(i.child)
+
+        for i in value:
+            self.add_titled(i.child, None, i.title)

--- a/ignis/widgets/stack_page.py
+++ b/ignis/widgets/stack_page.py
@@ -1,0 +1,37 @@
+from gi.repository import Gtk, GObject  # type: ignore
+from ignis.gobject import IgnisGObject
+
+
+class StackPage(IgnisGObject):
+    """
+    Bases: :class:`~ignis.gobject.IgnisGObject`
+
+    Intented to use with :class:`~ignis.widgets.Widget.Stack`.
+
+    .. warning::
+        It is not a widget.
+    """
+
+    def __init__(self, title: str, child: Gtk.Widget):
+        super().__init__()
+        self._title = title
+        self._child = child
+
+    @GObject.Property
+    def title(self) -> str:
+        """
+        - required, read-only
+
+        The title.
+        It will be used by :class:`~ignis.widgets.Widget.StackSwitcher` to display :attr:`child` in a tab bar.
+        """
+        return self._title
+
+    @GObject.Property
+    def child(self) -> Gtk.Widget:
+        """
+        - required, read-only
+
+        The child widget.
+        """
+        return self._child

--- a/ignis/widgets/stack_switcher.py
+++ b/ignis/widgets/stack_switcher.py
@@ -1,0 +1,17 @@
+from gi.repository import Gtk  # type: ignore
+from ignis.base_widget import BaseWidget
+
+
+class StackSwitcher(Gtk.StackSwitcher, BaseWidget):
+    """
+    Bases: :class:`Gtk.StackSwitcher`
+
+    The StackSwitcher shows a row of buttons to switch between :class:`~ignis.widgets.Widget.Stack` pages.
+    """
+
+    __gtype_name__ = "IgnisStackSwitcher"
+    __gproperties__ = {**BaseWidget.gproperties}
+
+    def __init__(self, **kwargs):
+        Gtk.Label.__init__(self)
+        BaseWidget.__init__(self, **kwargs)

--- a/ignis/widgets/stack_switcher.py
+++ b/ignis/widgets/stack_switcher.py
@@ -13,5 +13,5 @@ class StackSwitcher(Gtk.StackSwitcher, BaseWidget):
     __gproperties__ = {**BaseWidget.gproperties}
 
     def __init__(self, **kwargs):
-        Gtk.Label.__init__(self)
+        Gtk.StackSwitcher.__init__(self)
         BaseWidget.__init__(self, **kwargs)


### PR DESCRIPTION
Example usage:
```python
from ignis.widgets import Widget

stack = Widget.Stack(
    child=[
        Widget.StackPage(
            title="page 1", child=Widget.Label(label="welcome to page 1!")
        ),
        Widget.StackPage(
            title="page 2", child=Widget.Label(label="welcome to page 2!")
        ),
        Widget.StackPage(
            title="page 3", child=Widget.Label(label="welcome to page 3!")
        ),
    ]
)

Widget.Box(
    vertical=True,
    # you should add both StackSwitcher and Stack.
    child=[Widget.StackSwitcher(stack=stack), stack],
)
```

Closes: #71