### PR TITLE
Fix(nix): GVC not found

### DIFF
--- a/nix/ignis.nix
+++ b/nix/ignis.nix
@@ -51,7 +51,7 @@ pkgs.stdenv.mkDerivation {
 
   buildPhase = ''
     cd ..
-    meson setup build --prefix=$out --libdir=lib/ignis
+    meson setup build --prefix=$out
     ninja -C build
   '';
 


### PR DESCRIPTION
Looks like the lib_dir path is incorrect since now `gvc.meson.build` has changed.

Also, I noticed the nixfiles are not formatted, would you mind if I open another PR (or in this PR) format it with `nix-formatter-rfc`?