### PR TITLE
fix(tray): add icon theme of item to search path

### DIFF
--- a/ignis/services/system_tray/item.py
+++ b/ignis/services/system_tray/item.py
@@ -76,7 +76,6 @@ class SystemTrayItem(IgnisGObject):
         self.emit("ready")
 
     def __sync_icon(self) -> None:
-
         icon_name = self.__dbus.IconName
         attention_icon_name = self.__dbus.AttentionIconName
         icon_pixmap = self.__dbus.IconPixmap
@@ -94,8 +93,6 @@ class SystemTrayItem(IgnisGObject):
                 icon_theme.add_search_path(icon_path)
                 self._icon = icon_name
 
-
-
         elif attention_icon_name:
             self._icon = attention_icon_name
 
@@ -109,7 +106,6 @@ class SystemTrayItem(IgnisGObject):
             self._icon = "image-missing"
 
         self.notify("icon")
-
 
     @GObject.Signal
     def ready(self): ...  # user shouldn't connect to this signal

--- a/ignis/services/system_tray/item.py
+++ b/ignis/services/system_tray/item.py
@@ -82,16 +82,9 @@ class SystemTrayItem(IgnisGObject):
         attention_icon_pixmap = self.__dbus.AttentionIconPixmap
 
         if icon_name:
-            if self._icon_theme.has_icon(icon_name):
-                self._icon = icon_name
-            else:
-                icon_path = self.__dbus.IconThemePath
-                display = Gdk.Display.get_default()
-                if not display:
-                    raise DisplayNotFoundError()
-                icon_theme = Gtk.IconTheme.get_for_display(display)
-                icon_theme.add_search_path(icon_path)
-                self._icon = icon_name
+            self._icon = icon_name
+            if not self._icon_theme.has_icon(icon_name):
+                self._icon_theme.add_search_path(self.__dbus.IconThemePath)
 
         elif attention_icon_name:
             self._icon = attention_icon_name

--- a/ignis/services/system_tray/item.py
+++ b/ignis/services/system_tray/item.py
@@ -88,7 +88,7 @@ class SystemTrayItem(IgnisGObject):
                 icon_path = self.__dbus.IconThemePath
                 display = Gdk.Display.get_default()
                 if not display:
-                    raise DisplayNotFoundError("No display found!")
+                    raise DisplayNotFoundError()
                 icon_theme = Gtk.IconTheme.get_for_display(display)
                 icon_theme.add_search_path(icon_path)
                 self._icon = icon_name

--- a/ignis/services/system_tray/item.py
+++ b/ignis/services/system_tray/item.py
@@ -81,10 +81,11 @@ class SystemTrayItem(IgnisGObject):
         icon_pixmap = self.__dbus.IconPixmap
         attention_icon_pixmap = self.__dbus.AttentionIconPixmap
 
+        icon_theme_path: str | None = self.__dbus.IconThemePath
         if icon_name:
             self._icon = icon_name
-            if not self._icon_theme.has_icon(icon_name):
-                self._icon_theme.add_search_path(self.__dbus.IconThemePath)
+            if not self._icon_theme.has_icon(icon_name) and icon_theme_path is not None:
+                self._icon_theme.add_search_path(icon_theme_path)
 
         elif attention_icon_name:
             self._icon = attention_icon_name


### PR DESCRIPTION
I issued about spotify icon before https://github.com/linkfrg/ignis/issues/61
It got fixed in Arch. But It didn't get fixed in NixOS or spotify-launcher in Arch. Since it was using absolute path, it coudn't fix it. So I added this to fix it...