### PR TITLE
feat: support Grass Sass compiler as a fallback

### DIFF
--- a/ignis/app.py
+++ b/ignis/app.py
@@ -238,7 +238,7 @@ class IgnisApp(Gtk.Application, IgnisGObject):
         """
         Apply a CSS/SCSS/SASS style from a path.
         If ``style_path`` has a ``.sass`` or ``.scss`` extension, it will be automatically compiled.
-        Requires ``dart-sass`` for SASS/SCSS compilation.
+        Requires either ``dart-sass`` or ``grass-sass`` for SASS/SCSS compilation.
 
         Args:
             style_path: Path to the .css/.scss/.sass file.

--- a/ignis/app.py
+++ b/ignis/app.py
@@ -233,7 +233,10 @@ class IgnisApp(Gtk.Application, IgnisGObject):
         self._config_path = config_path
 
     def apply_css(
-        self, style_path: str, style_priority: StylePriority = "application"
+        self,
+        style_path: str,
+        style_priority: StylePriority = "application",
+        compiler: Literal["sass", "grass"] | None = None
     ) -> None:
         """
         Apply a CSS/SCSS/SASS style from a path.
@@ -243,6 +246,7 @@ class IgnisApp(Gtk.Application, IgnisGObject):
         Args:
             style_path: Path to the .css/.scss/.sass file.
             style_priority: A priority of the CSS style. More info about style priorities: :obj:`Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION`.
+            compiler: The desired Sass compiler.
 
         .. warning::
             ``style_priority`` won't affect a style applied to widgets using the ``style`` property,
@@ -268,7 +272,7 @@ class IgnisApp(Gtk.Application, IgnisGObject):
             )
 
         if style_path.endswith(".scss") or style_path.endswith(".sass"):
-            css_style = Utils.sass_compile(path=style_path)
+            css_style = Utils.sass_compile(path=style_path, compiler=compiler)
         elif style_path.endswith(".css"):
             with open(style_path) as file:
                 css_style = file.read()

--- a/ignis/app.py
+++ b/ignis/app.py
@@ -236,7 +236,7 @@ class IgnisApp(Gtk.Application, IgnisGObject):
         self,
         style_path: str,
         style_priority: StylePriority = "application",
-        compiler: Literal["sass", "grass"] | None = None
+        compiler: Literal["sass", "grass"] | None = None,
     ) -> None:
         """
         Apply a CSS/SCSS/SASS style from a path.

--- a/ignis/exceptions.py
+++ b/ignis/exceptions.py
@@ -251,7 +251,8 @@ class SassNotFoundError(Exception):
 
     def __init__(self, *args: object) -> None:
         super().__init__(
-            "Sass compiler not found! To compile SCSS/SASS, install either dart-sass or grass-sass", *args
+            "Sass compiler not found! To compile SCSS/SASS, install either dart-sass or grass-sass",
+            *args,
         )
 
 

--- a/ignis/exceptions.py
+++ b/ignis/exceptions.py
@@ -227,7 +227,7 @@ class GstPluginNotFoundError(Exception):
 
 class SassCompilationError(Exception):
     """
-    Raised when Dart Sass compilation fails.
+    Raised when the Sass compilation fails.
     """
 
     def __init__(self, stderr: str, *args: object) -> None:
@@ -239,19 +239,19 @@ class SassCompilationError(Exception):
         """
         - required, read-only
 
-        The stderr output from Dart Sass.
+        The stderr output from the Sass compiler.
         """
         return self._stderr
 
 
-class DartSassNotFoundError(Exception):
+class SassNotFoundError(Exception):
     """
-    Raised when Dart Sass is not found.
+    Raised when a compatible Sass compiler is not found.
     """
 
     def __init__(self, *args: object) -> None:
         super().__init__(
-            "Dart Sass not found! To compile SCSS/SASS, install dart-sass", *args
+            "Sass compiler not found! To compile SCSS/SASS, install either dart-sass or grass-sass", *args
         )
 
 

--- a/ignis/utils/sass.py
+++ b/ignis/utils/sass.py
@@ -1,31 +1,26 @@
 import os
 import shutil
 import subprocess
+import typing
 from ignis.exceptions import SassCompilationError, SassNotFoundError
 
 TEMP_DIR = "/tmp/ignis"
 COMPILED_CSS = f"{TEMP_DIR}/compiled.css"
 os.makedirs(TEMP_DIR, exist_ok=True)
 
-# pick a Sass compiler
-sass_compiler = None
+# resolve Sass compiler paths and pick a default one
+# "sass" (dart-sass) is the default,
+# "grass" is an API-compatible drop-in replacement
+known_compilers = typing.Literal["sass", "grass"]
+sass_compilers = {}
+for cmd in typing.get_args(known_compilers):
+    path = shutil.which(cmd)
+    if path:
+        sass_compilers[cmd] = path
+        
 
-sass_compilers = [
-    "sass", # dart-sass
-    "grass" # grass-sass
-]
-
-for compiler in sass_compilers:
-    sass_compiler = shutil.which(compiler)
-
-    if sass_compiler:
-        break
-
-
-def compile_file(path: str) -> str:
-    assert sass_compiler
-
-    result = subprocess.run([sass_compiler, path, COMPILED_CSS], capture_output=True)
+def compile_file(path: str, compiler_path: str) -> str:
+    result = subprocess.run([compiler_path, path, COMPILED_CSS], capture_output=True)
 
     if result.returncode != 0:
         raise SassCompilationError(result.stderr.decode())
@@ -34,11 +29,9 @@ def compile_file(path: str) -> str:
         return file.read()
 
 
-def compile_string(string: str) -> str:
-    assert sass_compiler
-
+def compile_string(string: str, compiler_path: str) -> str:
     process = subprocess.Popen(
-        [sass_compiler, "--stdin"],
+        [compiler_path, "--stdin"],
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -51,7 +44,7 @@ def compile_string(string: str) -> str:
         return stdout.decode()
 
 
-def sass_compile(path: str | None = None, string: str | None = None) -> str:
+def sass_compile(path: str | None = None, string: str | None = None, compiler: known_compilers | None = None) -> str:
     """
     Compile a SASS/SCSS file or string.
     Requires either `Dart Sass <https://sass-lang.com/dart-sass/>`_
@@ -60,20 +53,29 @@ def sass_compile(path: str | None = None, string: str | None = None) -> str:
     Args:
         path: The path to the SASS/SCSS file.
         string: A string with SASS/SCSS style.
+        compiler: The desired Sass compiler, either ``sass`` or ``grass``.
 
     Raises:
         TypeError: If neither of the arguments is provided.
         SassNotFoundError: If no Sass compiler is available.
         SassCompilationError: If an error occurred while compiling SASS/SCSS.
     """
-    if not sass_compiler:
+    if not sass_compilers:
         raise SassNotFoundError()
 
+    if compiler and compiler not in sass_compilers:
+        raise SassNotFoundError()
+
+    if compiler:
+        compiler_path = sass_compilers[compiler]
+    else:
+        compiler_path = next(iter(sass_compilers.values()))
+
     if string:
-        return compile_string(string)
+        return compile_string(string, compiler_path)
 
     elif path:
-        return compile_file(path)
+        return compile_file(path, compiler_path)
 
     else:
         raise TypeError("sass_compile() requires at least one positional argument")

--- a/ignis/utils/sass.py
+++ b/ignis/utils/sass.py
@@ -1,14 +1,31 @@
 import os
+import shutil
 import subprocess
-from ignis.exceptions import SassCompilationError, DartSassNotFoundError
+from ignis.exceptions import SassCompilationError, SassNotFoundError
 
 TEMP_DIR = "/tmp/ignis"
 COMPILED_CSS = f"{TEMP_DIR}/compiled.css"
 os.makedirs(TEMP_DIR, exist_ok=True)
 
+# pick a Sass compiler
+sass_compiler = None
+
+sass_compilers = [
+    "sass", # dart-sass
+    "grass" # grass-sass
+]
+
+for compiler in sass_compilers:
+    sass_compiler = shutil.which(compiler)
+
+    if sass_compiler:
+        break
+
 
 def compile_file(path: str) -> str:
-    result = subprocess.run(["sass", path, COMPILED_CSS], capture_output=True)
+    assert sass_compiler
+
+    result = subprocess.run([sass_compiler, path, COMPILED_CSS], capture_output=True)
 
     if result.returncode != 0:
         raise SassCompilationError(result.stderr.decode())
@@ -18,8 +35,10 @@ def compile_file(path: str) -> str:
 
 
 def compile_string(string: str) -> str:
+    assert sass_compiler
+
     process = subprocess.Popen(
-        ["sass", "--stdin"],
+        [sass_compiler, "--stdin"],
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -35,7 +54,8 @@ def compile_string(string: str) -> str:
 def sass_compile(path: str | None = None, string: str | None = None) -> str:
     """
     Compile a SASS/SCSS file or string.
-    Requires `Dart Sass <https://sass-lang.com/dart-sass/>`_.
+    Requires either `Dart Sass <https://sass-lang.com/dart-sass/>`_
+    or `Grass <https://github.com/connorskees/grass>`_.
 
     Args:
         path: The path to the SASS/SCSS file.
@@ -43,11 +63,11 @@ def sass_compile(path: str | None = None, string: str | None = None) -> str:
 
     Raises:
         TypeError: If neither of the arguments is provided.
-        DartSassNotFoundError: If Dart Sass not found.
+        SassNotFoundError: If no Sass compiler is available.
         SassCompilationError: If an error occurred while compiling SASS/SCSS.
     """
-    if not os.path.exists("/bin/sass"):
-        raise DartSassNotFoundError()
+    if not sass_compiler:
+        raise SassNotFoundError()
 
     if string:
         return compile_string(string)

--- a/ignis/utils/sass.py
+++ b/ignis/utils/sass.py
@@ -43,7 +43,11 @@ def compile_string(string: str, compiler_path: str) -> str:
         return stdout.decode()
 
 
-def sass_compile(path: str | None = None, string: str | None = None, compiler: Literal["sass", "grass"] | None = None) -> str:
+def sass_compile(
+    path: str | None = None,
+    string: str | None = None,
+    compiler: Literal["sass", "grass"] | None = None,
+) -> str:
     """
     Compile a SASS/SCSS file or string.
     Requires either `Dart Sass <https://sass-lang.com/dart-sass/>`_

--- a/ignis/utils/sass.py
+++ b/ignis/utils/sass.py
@@ -1,7 +1,7 @@
 import os
 import shutil
 import subprocess
-import typing
+from typing import Literal
 from ignis.exceptions import SassCompilationError, SassNotFoundError
 
 TEMP_DIR = "/tmp/ignis"
@@ -11,13 +11,12 @@ os.makedirs(TEMP_DIR, exist_ok=True)
 # resolve Sass compiler paths and pick a default one
 # "sass" (dart-sass) is the default,
 # "grass" is an API-compatible drop-in replacement
-known_compilers = typing.Literal["sass", "grass"]
 sass_compilers = {}
-for cmd in typing.get_args(known_compilers):
+for cmd in ("sass", "grass"):
     path = shutil.which(cmd)
     if path:
         sass_compilers[cmd] = path
-        
+
 
 def compile_file(path: str, compiler_path: str) -> str:
     result = subprocess.run([compiler_path, path, COMPILED_CSS], capture_output=True)
@@ -44,7 +43,7 @@ def compile_string(string: str, compiler_path: str) -> str:
         return stdout.decode()
 
 
-def sass_compile(path: str | None = None, string: str | None = None, compiler: known_compilers | None = None) -> str:
+def sass_compile(path: str | None = None, string: str | None = None, compiler: Literal["sass", "grass"] | None = None) -> str:
     """
     Compile a SASS/SCSS file or string.
     Requires either `Dart Sass <https://sass-lang.com/dart-sass/>`_


### PR DESCRIPTION
This adds support for an alternate Sass compiler using import-time detection, and also fixes a failure to find sass if it's in a weird location (but still in PATH).

I'm packaging Ignis for Gentoo and this was easier than bringing in the Dart ecosystem, which, turns out, is completely missing on Gentoo.