### PR TITLE
refactor!: overhaul `DBusProxy` initialization & add support for async initialization

### DIFF
--- a/ignis/client.py
+++ b/ignis/client.py
@@ -30,7 +30,7 @@ class IgnisClient:
     """
 
     def __init__(self):
-        self.__dbus = DBusProxy(
+        self.__dbus = DBusProxy.new(
             name="com.github.linkfrg.ignis",
             object_path="/com/github/linkfrg/ignis",
             interface_name="com.github.linkfrg.ignis",

--- a/ignis/dbus.py
+++ b/ignis/dbus.py
@@ -246,7 +246,7 @@ class DBusService(IgnisGObject):
 class DBusProxy(IgnisGObject):
     """
     A class to interact with D-Bus services (create a D-Bus proxy).
-    Unlike :class:`Gio.DBusProxy>`,
+    Unlike :class:`Gio.DBusProxy`,
     this class also provides convenient pythonic property access.
 
     To call a D-Bus method, use the standart pythonic way.
@@ -257,7 +257,7 @@ class DBusProxy(IgnisGObject):
     .. code-block:: python
 
         from ignis.dbus import DBusProxy
-        proxy = DBusProxy(...)
+        proxy = DBusProxy.new(...)
         result = proxy.MyMethod("(is)", 42, "hello")
         print(result)
 
@@ -266,7 +266,7 @@ class DBusProxy(IgnisGObject):
     .. code-block:: python
 
         from ignis.dbus import DBusProxy
-        proxy = DBusProxy(...)
+        proxy = DBusProxy.new(...)
         print(proxy.MyValue)
 
     To set a D-Bus property:
@@ -274,30 +274,49 @@ class DBusProxy(IgnisGObject):
     .. code-block:: python
 
         from ignis.dbus import DBusProxy
-        proxy = DBusProxy(...)
+        proxy = DBusProxy.new(...)
         # pass GLib.Variant as new property value
         proxy.MyValue = GLib.Variant("s", "Hello world!")
+
+    Args:
+        bus_type: The type of the bus.
+        gproxy: An instance of :class:`Gio.DBusProxy`.
     """
 
-    def __init__(
-        self,
+    def __init__(self, bus_type: Literal["session", "system"], gproxy: Gio.DBusProxy):
+        super().__init__()
+        self._bus_type = bus_type
+        self._methods: list[str] = []
+        self._properties: list[str] = []
+
+        self._gproxy = gproxy
+
+        for method in self.info.methods:
+            self._methods.append(method.name)
+
+        for prop in self.info.properties:
+            self._properties.append(prop.name)
+
+    @classmethod
+    def new(
+        cls,
         name: str,
         object_path: str,
         interface_name: str,
         info: Gio.DBusInterfaceInfo,
         bus_type: Literal["session", "system"] = "session",
-    ):
-        super().__init__()
-        self._name = name
-        self._object_path = object_path
-        self._interface_name = interface_name
-        self._info = info
-        self._bus_type = bus_type
+    ) -> "DBusProxy":
+        """
+        Synchronously initialize a new instance.
 
-        self._methods: list[str] = []
-        self._properties: list[str] = []
-
-        self._gproxy = Gio.DBusProxy.new_for_bus_sync(
+        Args:
+            name: A bus name (well-known or unique).
+            object_path: An object path.
+            interface_name: A D-Bus interface name.
+            info: A :class:`Gio.DBusInterfaceInfo` instance. You can get it from XML using :class:`~ignis.utils.Utils.load_interface_xml`.
+            bus_type: The type of the bus.
+        """
+        gproxy = Gio.DBusProxy.new_for_bus_sync(
             BUS_TYPE[bus_type],
             Gio.DBusProxyFlags.NONE,
             info,
@@ -306,66 +325,98 @@ class DBusProxy(IgnisGObject):
             interface_name,
             None,
         )
+        return cls(bus_type=bus_type, gproxy=gproxy)
 
-        for i in info.methods:
-            self._methods.append(i.name)
+    @classmethod
+    def new_async(
+        cls,
+        name: str,
+        object_path: str,
+        interface_name: str,
+        info: Gio.DBusInterfaceInfo,
+        bus_type: Literal["session", "system"] = "session",
+        callback: Callable | None = None,
+    ) -> None:
+        """
+        Asynchronously initialize a new instance.
 
-        for i in info.properties:  # type: ignore
-            self._properties.append(i.name)
+        Args:
+            name: A bus name (well-known or unique).
+            object_path: An object path.
+            interface_name: A D-Bus interface name.
+            info: A :class:`Gio.DBusInterfaceInfo` instance. You can get it from XML using :class:`~ignis.utils.Utils.load_interface_xml`.
+            bus_type: The type of the bus.
+            callback: A function to call when the initialization is complete. The function will receive a newly initialized instance of this class.
+        """
+
+        def finish(x, res):
+            gproxy = Gio.DBusProxy.new_for_bus_finish(res)
+            proxy = cls(bus_type=bus_type, gproxy=gproxy)
+            if callback:
+                callback(proxy)
+
+        Gio.DBusProxy.new_for_bus(
+            BUS_TYPE[bus_type],
+            Gio.DBusProxyFlags.NONE,
+            info,
+            name,
+            object_path,
+            interface_name,
+            None,
+            finish,
+        )
 
     @GObject.Property
     def name(self) -> str:
         """
-        - required, read-only
+        - read-only
 
         A bus name (well-known or unique).
         """
-        return self._name
+        return self._gproxy.props.g_name
 
     @GObject.Property
     def object_path(self) -> str:
         """
-        - required, read-only
+        - read-only
 
         An object path.
         """
-        return self._object_path
+        return self._gproxy.props.g_object_path
 
     @GObject.Property
     def interface_name(self) -> str:
         """
-        - required, read-only
+        - read-only
 
         A D-Bus interface name.
         """
-        return self._interface_name
+        return self._gproxy.props.g_interface_name
 
     @GObject.Property
     def info(self) -> Gio.DBusInterfaceInfo:
         """
-        - required, read-only
+        - read-only
 
         A :class:`Gio.DBusInterfaceInfo` instance.
 
         You can get it from XML using :class:`~ignis.utils.Utils.load_interface_xml`.
         """
-        return self._info
+        return self._gproxy.props.g_interface_info
 
     @GObject.Property
     def bus_type(self) -> Literal["session", "system"]:
         """
-        - optional, read-only
+        - read-only
 
         The type of the bus.
-
-        Default: ``session``.
         """
         return self._bus_type
 
     @GObject.Property
     def gproxy(self) -> Gio.DBusProxy:
         """
-        - not argument, read-only
+        - read-only
 
         The :class:`Gio.DBusProxy` instance.
         """
@@ -374,7 +425,7 @@ class DBusProxy(IgnisGObject):
     @GObject.Property
     def connection(self) -> Gio.DBusConnection:
         """
-        - not argument, read-only
+        - read-only
 
         The instance of :class:`Gio.DBusConnection` for this proxy.
         """
@@ -383,7 +434,7 @@ class DBusProxy(IgnisGObject):
     @GObject.Property
     def methods(self) -> list[str]:
         """
-        - not argument, read-only
+        - read-only
 
         A list of methods exposed by D-Bus service.
         """
@@ -392,7 +443,7 @@ class DBusProxy(IgnisGObject):
     @GObject.Property
     def properties(self) -> list[str]:
         """
-        - not argument, read-only
+        - read-only
 
         A list of properties exposed by D-Bus service.
         """
@@ -401,16 +452,16 @@ class DBusProxy(IgnisGObject):
     @GObject.Property
     def has_owner(self) -> bool:
         """
-        - not argument, read-only
+        - read-only
 
         Whether the ``name`` has an owner.
         """
-        dbus = DBusProxy(
+        dbus = DBusProxy.new(
             name="org.freedesktop.DBus",
             object_path="/org/freedesktop/DBus",
             interface_name="org.freedesktop.DBus",
             info=Utils.load_interface_xml("org.freedesktop.DBus"),
-            bus_type=self._bus_type,
+            bus_type=self.bus_type,
         )
         return dbus.NameHasOwner("(s)", self.name)
 

--- a/ignis/dbus_menu.py
+++ b/ignis/dbus_menu.py
@@ -54,7 +54,7 @@ class DBusMenu(Gtk.PopoverMenu):
         self._name = name
         self._object_path = object_path
 
-        self.__proxy = DBusProxy(
+        self.__proxy = DBusProxy.new(
             name=name,
             object_path=object_path,
             interface_name="com.canonical.dbusmenu",

--- a/ignis/services/backlight/device.py
+++ b/ignis/services/backlight/device.py
@@ -35,7 +35,7 @@ class BacklightDevice(IgnisGObject):
             else None,
         )
 
-        self.__session_proxy = DBusProxy(
+        self.__session_proxy = DBusProxy.new(
             name="org.freedesktop.login1",
             object_path=get_session_path(),
             info=Utils.load_interface_xml("org.freedesktop.login1.Session"),

--- a/ignis/services/backlight/util.py
+++ b/ignis/services/backlight/util.py
@@ -4,7 +4,7 @@ from ignis.utils import Utils
 
 
 def get_session_path() -> str:
-    proxy = DBusProxy(
+    proxy = DBusProxy.new(
         name="org.freedesktop.login1",
         object_path="/org/freedesktop/login1",
         info=Utils.load_interface_xml("org.freedesktop.login1.Manager"),

--- a/ignis/services/mpris/player.py
+++ b/ignis/services/mpris/player.py
@@ -21,14 +21,14 @@ class MprisPlayer(IgnisGObject):
         self._position: int = -1
         self._art_url: str | None = None
 
-        self.__mpris_proxy = DBusProxy(
+        self.__mpris_proxy = DBusProxy.new(
             name=name,
             object_path="/org/mpris/MediaPlayer2",
             interface_name="org.mpris.MediaPlayer2",
             info=Utils.load_interface_xml("org.mpris.MediaPlayer2"),
         )
 
-        self.__player_proxy = DBusProxy(
+        self.__player_proxy = DBusProxy.new(
             name=self.__mpris_proxy.name,
             object_path=self.__mpris_proxy.object_path,
             interface_name="org.mpris.MediaPlayer2.Player",

--- a/ignis/services/mpris/service.py
+++ b/ignis/services/mpris/service.py
@@ -24,7 +24,7 @@ class MprisService(BaseService):
         super().__init__()
         self._players: dict[str, MprisPlayer] = {}
 
-        self.__dbus = DBusProxy(
+        self.__dbus = DBusProxy.new(
             name="org.freedesktop.DBus",
             object_path="/org/freedesktop/DBus",
             interface_name="org.freedesktop.DBus",

--- a/ignis/services/notifications/service.py
+++ b/ignis/services/notifications/service.py
@@ -69,7 +69,7 @@ class NotificationService(BaseService):
         self.__load_notifications()
 
     def __on_name_lost(self, *args) -> None:
-        proxy = DBusProxy(
+        proxy = DBusProxy.new(
             name="org.freedesktop.Notifications",
             interface_name="org.freedesktop.Notifications",
             object_path="/org/freedesktop/Notifications",

--- a/ignis/services/recorder/session.py
+++ b/ignis/services/recorder/session.py
@@ -12,7 +12,7 @@ class SessionManager:
     """
 
     def __init__(self) -> None:
-        self.__dbus = DBusProxy(
+        self.__dbus = DBusProxy.new(
             name="org.freedesktop.portal.Desktop",
             object_path="/org/freedesktop/portal/desktop",
             interface_name="org.freedesktop.portal.ScreenCast",
@@ -50,7 +50,7 @@ class SessionManager:
         self._request_token_counter += 1
         request_token = f"u{self._request_token_counter}"
         request_path = f"/org/freedesktop/portal/desktop/request/{self._sender_name}/{request_token}"
-        request_proxy = DBusProxy(
+        request_proxy = DBusProxy.new(
             name="org.freedesktop.portal.Desktop",
             object_path=request_path,
             interface_name="org.freedesktop.portal.Request",

--- a/ignis/services/system_tray/item.py
+++ b/ignis/services/system_tray/item.py
@@ -21,7 +21,7 @@ class SystemTrayItem(IgnisGObject):
         self._status: str | None = None
         self._menu: DBusMenu | None = None
 
-        self. __dbus = DBusProxy.new(
+        self.__dbus = DBusProxy.new(
             name=name,
             object_path=object_path,
             interface_name="org.kde.StatusNotifierItem",

--- a/ignis/services/system_tray/item.py
+++ b/ignis/services/system_tray/item.py
@@ -21,7 +21,7 @@ class SystemTrayItem(IgnisGObject):
         self._status: str | None = None
         self._menu: DBusMenu | None = None
 
-        self.__dbus: DBusProxy = DBusProxy(
+        self. __dbus = DBusProxy.new(
             name=name,
             object_path=object_path,
             interface_name="org.kde.StatusNotifierItem",

--- a/ignis/services/system_tray/service.py
+++ b/ignis/services/system_tray/service.py
@@ -52,7 +52,7 @@ class SystemTrayService(BaseService):
         )
 
     def __on_name_lost(self, *args) -> None:
-        proxy = DBusProxy(
+        proxy = DBusProxy.new(
             name="org.kde.StatusNotifierWatcher",
             interface_name="org.kde.StatusNotifierWatcher",
             object_path="/StatusNotifierWatcher",

--- a/ignis/services/systemd/service.py
+++ b/ignis/services/systemd/service.py
@@ -41,7 +41,7 @@ class SystemdService(BaseService):
 
         self._bus_type = bus_type
 
-        self._proxy = DBusProxy(
+        self._proxy = DBusProxy.new(
             name="org.freedesktop.systemd1",
             object_path="/org/freedesktop/systemd1",
             interface_name="org.freedesktop.systemd1.Manager",

--- a/ignis/services/systemd/unit.py
+++ b/ignis/services/systemd/unit.py
@@ -20,7 +20,7 @@ class SystemdUnit(IgnisGObject):
         else:
             self._flags = Gio.DBusCallFlags.NONE
 
-        self._proxy = DBusProxy(
+        self._proxy = DBusProxy.new(
             name="org.freedesktop.systemd1",
             object_path=object_path,
             interface_name="org.freedesktop.systemd1.Unit",

--- a/ignis/services/upower/device.py
+++ b/ignis/services/upower/device.py
@@ -16,7 +16,7 @@ class UPowerDevice(IgnisGObject):
         self.__watching_props: dict[str, tuple[str, ...]] = {}
         self._object_path = object_path
 
-        self._proxy = DBusProxy(
+        self._proxy = DBusProxy.new(
             name="org.freedesktop.UPower",
             object_path=object_path,
             interface_name="org.freedesktop.UPower.Device",

--- a/ignis/services/upower/service.py
+++ b/ignis/services/upower/service.py
@@ -18,7 +18,7 @@ class UPowerService(BaseService):
     def __init__(self) -> None:
         super().__init__()
 
-        self._proxy = DBusProxy(
+        self._proxy = DBusProxy.new(
             name="org.freedesktop.UPower",
             object_path="/org/freedesktop/UPower",
             interface_name="org.freedesktop.UPower",


### PR DESCRIPTION
This PR brings two new methods to `DBusProxy`: `new` and `new_async` to replace the standard ``__init__``.
``__init__`` still can be used, but now it requires different arguments: `bus_type` and `gproxy`.
