### PR TITLE
feat!: follow XDG base directories

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug.yaml
+++ b/.github/ISSUE_TEMPLATE/1-bug.yaml
@@ -36,4 +36,4 @@ body:
       label: Additional Information
       description: |
         Anything that can help (Logs, Images, Videos, Configs, etc.). Please avoid pasting large text directly.
-        Logs can be found at `~/.ignis/ignis.log`.
+        Logs can be found at `$XDG_STATE_HOME/ignis/ignis.log` (`~/.local/state/ignis/ignis.log`).

--- a/ignis/cli.py
+++ b/ignis/cli.py
@@ -5,8 +5,9 @@ from ignis.client import IgnisClient
 from ignis.utils import Utils
 from ignis.exceptions import WindowNotFoundError
 from typing import Any
+from gi.repository import GLib  # type: ignore
 
-DEFAULT_CONFIG_PATH = "~/.config/ignis/config.py"
+DEFAULT_CONFIG_PATH = f"{GLib.get_user_config_dir()}/ignis/config.py"
 
 
 class OrderedGroup(click.Group):

--- a/ignis/logging.py
+++ b/ignis/logging.py
@@ -2,7 +2,7 @@ import sys
 from loguru import logger
 from gi.repository import GLib  # type: ignore
 
-LOG_DIR = f"{GLib.get_home_dir()}/.ignis"
+LOG_DIR = f"{GLib.get_user_state_dir()}/ignis"
 LOG_FILE = f"{LOG_DIR}/ignis.log"
 LOG_FORMAT = "{time:YYYY-MM-DD HH:mm:ss} [<level>{level}</level>] {message}"
 

--- a/ignis/logging.py
+++ b/ignis/logging.py
@@ -1,9 +1,8 @@
-import os
 import sys
 from loguru import logger
 from gi.repository import GLib  # type: ignore
 
-LOG_DIR = os.path.expanduser("~/.ignis")
+LOG_DIR = f"{GLib.get_home_dir()}/.ignis"
 LOG_FILE = f"{LOG_DIR}/ignis.log"
 LOG_FORMAT = "{time:YYYY-MM-DD HH:mm:ss} [<level>{level}</level>] {message}"
 


### PR DESCRIPTION
This PR brings support for XDG Base Directories instead of hard-coded paths like `~/.config/ignis`.
There is also a little breaking change: logs now stored at `$XDG_STATE_HOME/ignis/ignis.log` (`~/.local/state/ignis/ignis.log`).

Closes: #143
