### PR TITLE
fix(`SystemTrayItem`): move to asynchronous property synchronization

### DIFF
--- a/ignis/services/system_tray/item.py
+++ b/ignis/services/system_tray/item.py
@@ -92,7 +92,7 @@ class SystemTrayItem(IgnisGObject):
 
     def __sync_property(self, py_name: str) -> None:
         def callback(value):
-            if isinstance(value, GLib.GError):
+            if isinstance(value, GLib.Error):
                 return
 
             setattr(self, f"_{py_name}", value)


### PR DESCRIPTION
This PR brings asynchronous D-Bus property synchronization to `SystemTrayItem`.
This will affect mainly internal stuff.
Public API remains the same, except for a small changes in property type hints.
Some of them can be ``None``.

Closes: #140