### PR TITLE
docs: pin sphinx version to 8.1.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
+sphinx==8.1.0
 pydata-sphinx-theme>=0.15.4
 sphinx_design>=0.6.1
 sphinx_copybutton>=0.5.2


### PR DESCRIPTION
Workaround for tox-dev/sphinx-autodoc-typehints#523