### PR TITLE
fix(`RevealerWindow`): do not set `Revealer` as the child in the `revealer` setter

### DIFF
--- a/ignis/widgets/revealer_window.py
+++ b/ignis/widgets/revealer_window.py
@@ -80,4 +80,3 @@ class RevealerWindow(Window):
     @revealer.setter
     def revealer(self, value: Revealer) -> None:
         self._revealer = value
-        self.set_child(value)


### PR DESCRIPTION
Closes: #161