### PR TITLE
feat!(`HyprlandService`): move to GObject-based objects

### DIFF
--- a/docs/api/services/hyprland.rst
+++ b/docs/api/services/hyprland.rst
@@ -3,3 +3,12 @@ Hyprland
 
 .. autoclass:: ignis.services.hyprland.HyprlandService
     :members:
+
+.. autoclass:: ignis.services.hyprland.HyprlandWorkspace
+    :members:
+
+.. autoclass:: ignis.services.hyprland.HyprlandWindow
+    :members:
+
+.. autoclass:: ignis.services.hyprland.HyprlandKeyboard
+    :members:

--- a/ignis/services/hyprland/__init__.py
+++ b/ignis/services/hyprland/__init__.py
@@ -1,8 +1,14 @@
 from .service import HyprlandService
+from .workspace import HyprlandWorkspace
+from .window import HyprlandWindow
+from .keyboard import HyprlandKeyboard
 from .constants import HYPR_SOCKET_DIR, HYPRLAND_INSTANCE_SIGNATURE
 
 __all__ = [
     "HyprlandService",
+    "HyprlandWorkspace",
+    "HyprlandWindow",
+    "HyprlandKeyboard",
     "HYPRLAND_INSTANCE_SIGNATURE",
     "HYPR_SOCKET_DIR",
 ]

--- a/ignis/services/hyprland/_object.py
+++ b/ignis/services/hyprland/_object.py
@@ -1,0 +1,17 @@
+from ignis.gobject import IgnisGObject
+from typing import Any
+
+
+class HyprlandObject(IgnisGObject):
+    def __init__(self, match_dict: dict[str, Any] | None = None):
+        super().__init__()
+        if match_dict is None:
+            match_dict = {}
+        self._match_dict = match_dict
+
+    def _sync(self, data: dict[str, Any]) -> None:
+        for key, value in data.items():
+            prop_name = self._match_dict.get(key, key)
+            if value != getattr(self, f"_{prop_name}"):
+                setattr(self, f"_{prop_name}", value)
+                self.notify(prop_name)

--- a/ignis/services/hyprland/keyboard.py
+++ b/ignis/services/hyprland/keyboard.py
@@ -1,0 +1,136 @@
+from ignis.gobject import IgnisProperty
+from ._object import HyprlandObject
+
+MATCH_DICT = {
+    "capsLock": "caps_lock",
+    "numLock": "num_lock",
+}
+
+
+class HyprlandKeyboard(HyprlandObject):
+    """
+    A keyboard.
+    """
+
+    def __init__(self, service):
+        super().__init__(match_dict=MATCH_DICT)
+        self._service = service
+        self._address: str = ""
+        self._name: str = ""
+        self._rules: str = ""
+        self._model: str = ""
+        self._layout: str = ""
+        self._variant: str = ""
+        self._options: str = ""
+        self._active_keymap: str = ""
+        self._caps_lock: bool = False
+        self._num_lock: bool = False
+        self._main: bool = False
+
+    @IgnisProperty
+    def address(self) -> str:
+        """
+        - read-only
+
+        The address of the keyboard.
+        """
+        return self._address
+
+    @IgnisProperty
+    def name(self) -> str:
+        """
+        - read-only
+
+        The name of the keyboard.
+        """
+        return self._name
+
+    @IgnisProperty
+    def rules(self) -> str:
+        """
+        - read-only
+
+        The rules of the keyboard.
+        """
+        return self._rules
+
+    @IgnisProperty
+    def model(self) -> str:
+        """
+        - read-only
+
+        The model of the keyboard.
+        """
+        return self._model
+
+    @IgnisProperty
+    def layout(self) -> str:
+        """
+        - read-only
+
+        The layout of the keyboard.
+        """
+        return self._layout
+
+    @IgnisProperty
+    def variant(self) -> str:
+        """
+        - read-only
+
+        The variant of the keyboard.
+        """
+        return self._variant
+
+    @IgnisProperty
+    def options(self) -> str:
+        """
+        - read-only
+
+        The options of the keyboard.
+        """
+        return self._options
+
+    @IgnisProperty
+    def active_keymap(self) -> str:
+        """
+        - read-only
+
+        The currently active keymap of the keyboard.
+        """
+        return self._active_keymap
+
+    @IgnisProperty
+    def caps_lock(self) -> bool:
+        """
+        - read-only
+
+        Whether Caps Lock is active.
+        """
+        return self._caps_lock
+
+    @IgnisProperty
+    def num_lock(self) -> bool:
+        """
+        - read-only
+
+        Whether Num Lock is active.
+        """
+        return self._num_lock
+
+    @IgnisProperty
+    def main(self) -> bool:
+        """
+        - read-only
+
+        Whether the keyboard is main.
+        """
+        return self._main
+
+    def switch_layout(self, layout: str) -> None:
+        """
+        Switch the keyboard layout.
+
+        Args:
+            layout: The layout to switch to. For example: ``next``, ``prev``, ``0``, ``1``, etc.
+        """
+        self._service.send_command(f"switchxkblayout {self.name} {layout}")

--- a/ignis/services/hyprland/service.py
+++ b/ignis/services/hyprland/service.py
@@ -54,7 +54,15 @@ class HyprlandService(BaseService):
             self.__sync_active_window()
 
     @GObject.Signal(arg_types=(HyprlandWorkspace,))
-    def workspace_added(self, *_): ...
+    def workspace_added(self, *_):
+        """
+        - Signal
+
+        Emitted when a new workspace has been added.
+
+        Args:
+            workspace (:class:`~ignis.services.hyprland.HyprlandWorkspace`): The instance of the workspace.
+        """
 
     @IgnisProperty
     def is_available(self) -> bool:

--- a/ignis/services/hyprland/service.py
+++ b/ignis/services/hyprland/service.py
@@ -1,71 +1,20 @@
 import json
 import os
 import socket
+from gi.repository import GObject  # type: ignore
 from ignis.utils import Utils
-from typing import Any
 from ignis.exceptions import HyprlandIPCNotFoundError
 from ignis.base_service import BaseService
 from ignis.gobject import IgnisProperty
 from .constants import HYPR_SOCKET_DIR
+from .workspace import HyprlandWorkspace
+from .keyboard import HyprlandKeyboard
+from .window import HyprlandWindow
 
 
 class HyprlandService(BaseService):
     """
     Hyprland IPC client.
-
-    .. note::
-        The contents of ``dict`` properties are not described here.
-        To find out their contents just print them into the terminal.
-
-        >>> print(hyprland.workspaces)
-        [
-            {
-                "id": 1,
-                "name": "1",
-                "monitor": "DP-1",
-                "monitorID": 1,
-                "windows": 1,
-                "hasfullscreen": False,
-                "lastwindow": "0x561dc35d2e80",
-                "lastwindowtitle": "hyprland.py - ignis - Visual Studio Code",
-            },
-            {
-                "id": 10,
-                "name": "10",
-                "monitor": "HDMI-A-1",
-                "monitorID": 0,
-                "windows": 1,
-                "hasfullscreen": False,
-                "lastwindow": "0x561dc3845f30",
-                "lastwindowtitle": "Type hints cheat sheet - mypy 1.11.2 documentation — Mozilla Firefox",
-            },
-        ]
-
-        >>> print(hyprland.active_window)
-        {
-            "address": "0x561dc35d2e80",
-            "mapped": True,
-            "hidden": False,
-            "at": [1942, 22],
-            "size": [1876, 1036],
-            "workspace": {"id": 1, "name": "1"},
-            "floating": False,
-            "pseudo": False,
-            "monitor": 1,
-            "class": "code-url-handler",
-            "title": "hyprland.py - ignis - Visual Studio Code",
-            "initialClass": "code-url-handler",
-            "initialTitle": "Visual Studio Code",
-            "pid": 1674,
-            "xwayland": False,
-            "pinned": False,
-            "fullscreen": 0,
-            "fullscreenClient": 0,
-            "grouped": [],
-            "tags": [],
-            "swallowing": "0x0",
-            "focusHistoryID": 0,
-        }
 
     Example usage:
 
@@ -75,26 +24,37 @@ class HyprlandService(BaseService):
 
         hyprland = HyprlandService.get_default()
 
-        print(hyprland.workspaces)
-        print(hyprland.kb_layout)
+        # Get IDs of all workspaces
+        print([i.id for i in hyprland.workspaces])
 
-        hyprland.connect("notify::kb-layout", lambda x, y: print(hyprland.kb_layout))
+        # Get the ID of the active workspace
+        print(hyprland.active_workspace.id)
+
+        # Get the currently active keyboard layout
+        print(hyprland.main_keyboard.active_keymap)
+
+        # Get the title of the active window
+        print(hyprland.active_window.title)
     """
 
     def __init__(self):
         super().__init__()
 
-        self._workspaces: list[dict[str, Any]] = []
-        self._active_workspace: dict[str, Any] = {}
-        self._kb_layout: str = ""
-        self._active_window: dict[str, Any] = {}
+        self._workspaces: dict[int, HyprlandWorkspace] = {}
+        self._active_workspace: HyprlandWorkspace = HyprlandWorkspace(self)
+        self._main_keyboard: HyprlandKeyboard = HyprlandKeyboard(self)
+        self._active_window: HyprlandWindow = HyprlandWindow()
 
         if self.is_available:
             self.__listen_events()
 
-            self.__sync_kb_layout()
             self.__sync_workspaces()
+            self.__sync_active_workspace()
+            self.__sync_main_keyboard()
             self.__sync_active_window()
+
+    @GObject.Signal(arg_types=(HyprlandWorkspace,))
+    def workspace_added(self, *_): ...
 
     @IgnisProperty
     def is_available(self) -> bool:
@@ -106,16 +66,16 @@ class HyprlandService(BaseService):
         return os.path.exists(HYPR_SOCKET_DIR)
 
     @IgnisProperty
-    def workspaces(self) -> list[dict[str, Any]]:
+    def workspaces(self) -> list[HyprlandWorkspace]:
         """
         - read-only
 
         A list of workspaces.
         """
-        return self._workspaces
+        return list(self._workspaces.values())
 
     @IgnisProperty
-    def active_workspace(self) -> dict[str, Any]:
+    def active_workspace(self) -> HyprlandWorkspace:
         """
         - read-only
 
@@ -124,16 +84,16 @@ class HyprlandService(BaseService):
         return self._active_workspace
 
     @IgnisProperty
-    def kb_layout(self) -> str:
+    def main_keyboard(self) -> HyprlandKeyboard:
         """
         - read-only
 
-        The currenly active keyboard layout.
+        The main keyboard.
         """
-        return self._kb_layout
+        return self._main_keyboard
 
     @IgnisProperty
-    def active_window(self) -> dict[str, Any]:
+    def active_window(self) -> HyprlandWindow:
         """
         - read-only
 
@@ -149,35 +109,87 @@ class HyprlandService(BaseService):
                 self.__on_event_received(event)
 
     def __on_event_received(self, event: str) -> None:
-        if (
-            event.startswith("workspace>>")
-            or event.startswith("destroyworkspace>>")
-            or event.startswith("focusedmon>>")
-        ):
-            self.__sync_workspaces()
-        elif event.startswith("activelayout>>"):
-            self.__sync_kb_layout()
+        event_data = event.split(">>")
+        event_type = event_data[0]
+        event_value = event_data[1]
 
-        elif event.startswith("activewindow>>"):
-            self.__sync_active_window()
+        match event_type:
+            case "destroyworkspace":
+                self.__destroy_workspace(int(event_value))
+            case "createworkspace":
+                self.__create_workspace(int(event_value))
+            case "workspace":
+                self.__sync_active_workspace()
+            case "focusedmon":
+                self.__sync_active_workspace()
+            case "activelayout":
+                self.__sync_active_layout(event_value.split(",")[1])
+            case "activewindow":
+                self.__sync_active_window()
+
+    def __create_workspace(self, id_: int) -> None:
+        for i in json.loads(self.send_command("j/workspaces")):
+            if id_ == i["id"]:
+                workspace_data = i
+                break
+        else:
+            workspace_data = None
+
+        if workspace_data:
+            workspace = HyprlandWorkspace(self)
+            workspace._sync(workspace_data)
+            self._workspaces[workspace_data["id"]] = workspace
+            self.__sort_workspaces()
+            self.emit("workspace-added", workspace)
+            self.notify("workspaces")
+
+    def __destroy_workspace(self, id_: int) -> None:
+        workspace = self._workspaces.pop(int(id_), None)
+        if workspace:
+            workspace.emit("destroyed")
+            self.__sort_workspaces()
+            self.notify("workspaces")
+
+    def __sort_workspaces(self) -> None:
+        self._workspaces = dict(sorted(self._workspaces.items()))
 
     def __sync_workspaces(self) -> None:
-        self._workspaces = sorted(
+        workspaces = sorted(
             json.loads(self.send_command("j/workspaces")), key=lambda x: x["id"]
         )
-        self._active_workspace = json.loads(self.send_command("j/activeworkspace"))
+        for workspace_data in workspaces:
+            workspace = self._workspaces.get(workspace_data["id"], None)
+            if workspace is None:
+                workspace = HyprlandWorkspace(self)
+
+            workspace._sync(workspace_data)
+            self._workspaces[workspace_data["id"]] = workspace
+
+        self.__sort_workspaces()
+
         self.notify("workspaces")
+
+    def __sync_active_workspace(self) -> None:
+        workspace_data = json.loads(self.send_command("j/activeworkspace"))
+        self._active_workspace._sync(workspace_data)
         self.notify("active-workspace")
 
-    def __sync_kb_layout(self) -> None:
-        for kb in json.loads(self.send_command("j/devices"))["keyboards"]:
-            if kb["main"]:
-                self._kb_layout = kb["active_keymap"]
-                self.notify("kb_layout")
+    def __sync_main_keyboard(self) -> None:
+        data_list = json.loads(self.send_command("j/devices"))["keyboards"]
+
+        for kb_data in data_list:
+            if kb_data["main"] is True:
+                self._main_keyboard._sync(kb_data)
+
+        self.notify("main-keyboard")
+
+    def __sync_active_layout(self, layout: str) -> None:
+        self._main_keyboard._sync({"active_keymap": layout})
 
     def __sync_active_window(self) -> None:
-        self._active_window = json.loads(self.send_command("j/activewindow"))
-        self.notify("active_window")
+        active_window_data = json.loads(self.send_command("j/activewindow"))
+        self.active_window._sync(active_window_data)
+        self.notify("active-window")
 
     def send_command(self, cmd: str) -> str:
         """
@@ -200,14 +212,6 @@ class HyprlandService(BaseService):
         with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
             sock.connect(f"{HYPR_SOCKET_DIR}/.socket.sock")
             return Utils.send_socket(sock, cmd, errors="ignore")
-
-    def switch_kb_layout(self) -> None:
-        """
-        Switch to the next keyboard layout.
-        """
-        for kb in json.loads(self.send_command("j/devices"))["keyboards"]:
-            if kb["main"]:
-                self.send_command(f"switchxkblayout {kb['name']} next")
 
     def switch_to_workspace(self, workspace_id: int) -> None:
         """

--- a/ignis/services/hyprland/window.py
+++ b/ignis/services/hyprland/window.py
@@ -1,0 +1,269 @@
+from ignis.gobject import IgnisProperty
+from typing import Any
+from ._object import HyprlandObject
+
+MATCH_DICT = {
+    "class": "class_name",
+    "initialClass": "initial_class",
+    "initialTitle": "initial_title",
+    "fullscreenClient": "fullscreen_client",
+    "focusHistoryID": "focus_history_id",
+    "inhibitingIdle": "inhibiting_idle",
+}
+
+
+class HyprlandWindow(HyprlandObject):
+    """
+    A window.
+    """
+
+    def __init__(self):
+        super().__init__(match_dict=MATCH_DICT)
+
+        self._address: str = ""
+        self._mapped: bool = False
+        self._hidden: bool = False
+        self._at: tuple[int, int] = (-1, -1)
+        self._size: tuple[int, int] = (-1, -1)
+        self._workspace_id: int = -1
+        self._workspace_name: str = ""
+        self._floating: bool = False
+        self._pseudo: bool = False
+        self._monitor: int = -1
+        self._class_name: str = ""
+        self._title: str = ""
+        self._initial_class: str = ""
+        self._initial_title: str = ""
+        self._pid: int = -1
+        self._xwayland: bool = False
+        self._pinned: bool = False
+        self._fullscreen: int = -1
+        self._fullscreen_client: int = -1
+        self._grouped: list = []
+        self._tags: list = []
+        self._swallowing: str = ""
+        self._focus_history_id: int = -1
+        self._inhibiting_idle: bool = False
+
+    def _sync(self, data: dict[str, Any]) -> None:
+        workspace = data.pop("workspace", None)
+        if workspace:
+            data["workspace_id"] = workspace["id"]
+            data["workspace_name"] = workspace["name"]
+        super()._sync(data)
+
+    @IgnisProperty
+    def address(self) -> str:
+        """
+        - read-only
+
+        The address of the window.
+        """
+        return self._address
+
+    @IgnisProperty
+    def mapped(self) -> bool:
+        """
+        - read-only
+
+        Whether the window is mapped.
+        """
+        return self._mapped
+
+    @IgnisProperty
+    def hidden(self) -> bool:
+        """
+        - read-only
+
+        Whether the window is hidden.
+        """
+        return self._hidden
+
+    @IgnisProperty
+    def at(self) -> tuple[int, int]:
+        """
+        - read-only
+
+        The coordinates of the window (e.g., ``(1280, 920)``).
+        """
+        return self._at
+
+    @IgnisProperty
+    def size(self) -> tuple[int, int]:
+        """
+        - read-only
+
+        The size of the window (e.g., ``(1280, 920)``).
+        """
+        return self._size
+
+    @IgnisProperty
+    def workspace_id(self) -> int:
+        """
+        - read-only
+
+        The ID of the workspace where the window is placed.
+        """
+        return self._workspace_id
+
+    @IgnisProperty
+    def workspace_name(self) -> str:
+        """
+        - read-only
+
+        The name of the workspace where the window is placed.
+        """
+        return self._workspace_name
+
+    @IgnisProperty
+    def floating(self) -> bool:
+        """
+        - read-only
+
+        Whether the window is floating.
+        """
+        return self._floating
+
+    @IgnisProperty
+    def pseudo(self) -> bool:
+        """
+        - read-only
+
+        Whether the window is pseudo.
+        """
+        return self._pseudo
+
+    @IgnisProperty
+    def monitor(self) -> int:
+        """
+        - read-only
+
+        The ID of the monitor where the window is placed.
+        """
+        return self._monitor
+
+    @IgnisProperty
+    def class_name(self) -> str:
+        """
+        - read-only
+
+        The class name of the window.
+        """
+        return self._class_name
+
+    @IgnisProperty
+    def title(self) -> str:
+        """
+        - read-only
+
+        The title of the window.
+        """
+        return self._title
+
+    @IgnisProperty
+    def initial_class(self) -> str:
+        """
+        - read-only
+
+        The initial class name of the window.
+        """
+        return self._initial_class
+
+    @IgnisProperty
+    def initial_title(self) -> str:
+        """
+        - read-only
+
+        The initial title of the window.
+        """
+        return self._initial_title
+
+    @IgnisProperty
+    def pid(self) -> int:
+        """
+        - read-only
+
+        The PID of the window.
+        """
+        return self._pid
+
+    @IgnisProperty
+    def xwayland(self) -> bool:
+        """
+        - read-only
+
+        Whether the window is running through Xwayland.
+        """
+        return self._xwayland
+
+    @IgnisProperty
+    def pinned(self) -> bool:
+        """
+        - read-only
+
+        Whether the window is pinned.
+        """
+        return self._pinned
+
+    @IgnisProperty
+    def fullscreen(self) -> int:
+        """
+        - read-only
+
+        The fullscreen mode.
+        """
+        return self._fullscreen
+
+    @IgnisProperty
+    def fullscreen_client(self) -> int:
+        """
+        - read-only
+
+        Fullscreen client.
+        """
+        return self._fullscreen_client
+
+    @IgnisProperty
+    def grouped(self) -> list:
+        """
+        - read-only
+
+        Grouped.
+        """
+        return self._grouped
+
+    @IgnisProperty
+    def tags(self) -> list:
+        """
+        - read-only
+
+        Tags.
+        """
+        return self._tags
+
+    @IgnisProperty
+    def swallowing(self) -> str:
+        """
+        - read-only
+
+        Swallowing.
+        """
+        return self._swallowing
+
+    @IgnisProperty
+    def focus_history_id(self) -> int:
+        """
+        - read-only
+
+        The focus history ID.
+        """
+        return self._focus_history_id
+
+    @IgnisProperty
+    def inhibiting_idle(self) -> bool:
+        """
+        - read-only
+
+        The inhibiting idle status.
+        """
+        return self._inhibiting_idle

--- a/ignis/services/hyprland/workspace.py
+++ b/ignis/services/hyprland/workspace.py
@@ -1,0 +1,114 @@
+from gi.repository import GObject  # type: ignore
+from ignis.gobject import IgnisProperty
+from ._object import HyprlandObject
+
+MATCH_DICT = {
+    "monitorID": "monitor_id",
+    "hasfullscreen": "has_fullscreen",
+    "lastwindow": "last_window",
+    "lastwindowtitle": "last_window_title",
+}
+
+
+class HyprlandWorkspace(HyprlandObject):
+    """
+    A workspace.
+    """
+
+    def __init__(self, service):
+        super().__init__(match_dict=MATCH_DICT)
+        self._service = service
+        self._id: int = -1
+        self._name: str = ""
+        self._monitor: str = ""
+        self._monitor_id: int = -1
+        self._windows: int = -1
+        self._has_fullscreen: bool = False
+        self._last_window: str = ""
+        self._last_window_title: str = ""
+
+    @GObject.Signal
+    def destroyed(self):
+        """
+        - Signal
+
+        Emitted when the workspace has been destroyed.
+        """
+
+    @IgnisProperty
+    def id(self) -> int:
+        """
+        - read-only
+
+        The ID of the workspace.
+        """
+        return self._id
+
+    @IgnisProperty
+    def name(self) -> str:
+        """
+        - read-only
+
+        The name of the workspace.
+        """
+        return self._name
+
+    @IgnisProperty
+    def monitor(self) -> str:
+        """
+        - read-only
+
+        The monitor on which the workspace is placed.
+        """
+        return self._monitor
+
+    @IgnisProperty
+    def monitor_id(self) -> int:
+        """
+        - read-only
+
+        The ID of the monitor on which the workspace is placed.
+        """
+        return self._monitor_id
+
+    @IgnisProperty
+    def windows(self) -> int:
+        """
+        - read-only
+
+        The amount of windows on the workspace.
+        """
+        return self._windows
+
+    @IgnisProperty
+    def has_fullscreen(self) -> bool:
+        """
+        - read-only
+
+        Whether the workspace has a fullscreen window.
+        """
+        return self._has_fullscreen
+
+    @IgnisProperty
+    def last_window(self) -> str:
+        """
+        - read-only
+
+        The latest window.
+        """
+        return self._last_window
+
+    @IgnisProperty
+    def last_window_title(self) -> str:
+        """
+        - read-only
+
+        The latest window title.
+        """
+        return self._last_window_title
+
+    def switch_to(self) -> None:
+        """
+        Switch to this workspace.
+        """
+        self._service.send_command(f"dispatch workspace {self.id}")


### PR DESCRIPTION
This PR brings objects inherited from ``IgnisGObject`` for Hyprland Service, replacing usual python dictionaries.
This approach allows to bind to properties and other GObject features.

New classes:
- ``HyprlandWorkspace``
- ``HyprlandWindow``
- ``HyprlandKeyboard``

Migration Guide:
1. Since these objects are not dictionaries anymore, you have to get properties like usual class attributes:
```python
# Old
hyprland.active_workspace["id"]
# New
hyprland.active_workspace.id
```

2. ``HyprlandService.kb_layout`` is removed, use ``HyprlandService.main_keyboard.active_keymap`` instead.
3. ``HyprlandService.switch_kb_layout()`` is removed, use ``HyprlandService.main_keyboard.switch_layout()`` instead (to restore the old functionality pass ``"next"`` as an argument to it).
4. ``HyprlandService.workspaces`` will not be notified on the active workspace change anymore.
If you want to restore the old functionality, use ``bind_many()``:
```python
# Old
hyprland.bind(
    "workspaces",
     transform=lambda value: [WorkspaceButton(i) for i in value],
)
# New
hyprland.bind_many(
    ["workspaces", "active_workspace"],
    transform=lambda workspaces, *_: [
        WorkspaceButton(i) for i in workspaces
    ],
)
```  

Closes: #95