### PR TITLE
fix(`Widget.Box`): remove child on unparent

### DIFF
--- a/ignis/widgets/box.py
+++ b/ignis/widgets/box.py
@@ -56,6 +56,14 @@ class Box(Gtk.Box, BaseWidget):
                 self.append(c)
 
     def append(self, child: Gtk.Widget) -> None:
+        _orig_unparent = child.unparent
+
+        def unparent_wrapper(*args, **kwargs):
+            self.remove(child)
+            _orig_unparent(*args, **kwargs)
+            child.unparent = _orig_unparent
+
+        child.unparent = unparent_wrapper
         self._child.append(child)
         super().append(child)
         self.notify("child")


### PR DESCRIPTION
Closes: #179

This PR dynamically replaces the ``unparent()`` function of a Widget.Box child with the wrapper that additionally removes that child using ``Widget.Box.remove()`` method. 