### PR TITLE
feat!: add explicit async versions of D-Bus methods for services

### DIFF
--- a/ignis/services/backlight/device.py
+++ b/ignis/services/backlight/device.py
@@ -84,5 +84,15 @@ class BacklightDevice(IgnisGObject):
             "backlight",
             self._device_name,
             value,
-            result_handler=lambda *args: None,
+        )
+
+    async def set_brighness_async(self, value: int) -> None:
+        """
+        Asynchronously set brightness.
+        """
+        await self.__session_proxy.SetBrightnessAsync(
+            "(ssu)",
+            "backlight",
+            self._device_name,
+            value,
         )

--- a/ignis/services/backlight/device.py
+++ b/ignis/services/backlight/device.py
@@ -86,9 +86,12 @@ class BacklightDevice(IgnisGObject):
             value,
         )
 
-    async def set_brighness_async(self, value: int) -> None:
+    async def set_brightness_async(self, value: int) -> None:
         """
         Asynchronously set brightness.
+
+        Args:
+            value: The value to set.
         """
         await self.__session_proxy.SetBrightnessAsync(
             "(ssu)",

--- a/ignis/services/backlight/service.py
+++ b/ignis/services/backlight/service.py
@@ -96,6 +96,9 @@ class BacklightService(BaseService):
     async def set_brightness_async(self, value: int) -> None:
         """
         Asynchronously set brightness for all devices.
+
+        Args:
+            value: The value to set.
         """
         for device in self._devices:
             await device.set_brighness_async(value)

--- a/ignis/services/backlight/service.py
+++ b/ignis/services/backlight/service.py
@@ -93,6 +93,13 @@ class BacklightService(BaseService):
         for device in self._devices:
             device.brightness = value
 
+    async def set_brightness_async(self, value: int) -> None:
+        """
+        Asynchronously set brightness for all devices.
+        """
+        for device in self._devices:
+            await device.set_brighness_async(value)
+
     @IgnisProperty
     def max_brightness(self) -> int:
         """

--- a/ignis/services/mpris/player.py
+++ b/ignis/services/mpris/player.py
@@ -361,10 +361,14 @@ class MprisPlayer(IgnisGObject):
 
     @position.setter
     def position(self, value: int) -> None:
-        self.__player_proxy.SetPosition(
-            "(ox)", self.track_id, value * 1_000_000, result_handler=lambda *args: None
-        )
+        self.__player_proxy.SetPosition("(ox)", self.track_id, value * 1_000_000)
         asyncio.create_task(self.__update_position())
+
+    async def set_position_async(self, value: int) -> None:
+        await self.__player_proxy.SetPositionAsync(
+            "(ox)", self.track_id, value * 1_000_000
+        )
+        await self.__update_position()
 
     @IgnisProperty
     def shuffle(self) -> bool:
@@ -406,37 +410,73 @@ class MprisPlayer(IgnisGObject):
         """
         Go to the next track.
         """
-        self.__player_proxy.Next(result_handler=lambda *args: None)
+        self.__player_proxy.Next()
+
+    async def next_async(self) -> None:
+        """
+        Asynchronous version of :func:`next`.
+        """
+        await self.__player_proxy.NextAsync()
 
     def previous(self) -> None:
         """
         Go to the previous track.
         """
-        self.__player_proxy.Previous(result_handler=lambda *args: None)
+        self.__player_proxy.Previous()
+
+    async def previous_async(self) -> None:
+        """
+        Asynchronous version of :func:`previous`.
+        """
+        self.__player_proxy.PreviousAsync()
 
     def pause(self) -> None:
         """
         Pause playback.
         """
-        self.__player_proxy.Pause(result_handler=lambda *args: None)
+        self.__player_proxy.Pause()
+
+    async def pause_async(self) -> None:
+        """
+        Asynchronous version of :func:`pause`.
+        """
+        await self.__player_proxy.PauseAsync()
 
     def play(self) -> None:
         """
         Start playback.
         """
-        self.__player_proxy.Play(result_handler=lambda *args: None)
+        self.__player_proxy.Play()
+
+    async def play_async(self) -> None:
+        """
+        Asynchronous version of :func:`play`.
+        """
+        await self.__player_proxy.PlayAsync()
 
     def play_pause(self) -> None:
         """
         Toggle between playing and pausing.
         """
-        self.__player_proxy.PlayPause(result_handler=lambda *args: None)
+        self.__player_proxy.PlayPause()
+
+    async def play_pause_async(self) -> None:
+        """
+        Asynchronous version of :func:`play_pause`.
+        """
+        await self.__player_proxy.PlayPauseAsync()
 
     def stop(self) -> None:
         """
         Stop playback and remove the MPRIS interface if supported by the player.
         """
-        self.__player_proxy.Stop(result_handler=lambda *args: None)
+        self.__player_proxy.Stop()
+
+    async def stop_async(self) -> None:
+        """
+        Asynchronous version of :func:`stop`.
+        """
+        await self.__player_proxy.StopAsync()
 
     def seek(self, offset: int) -> None:
         """
@@ -444,6 +484,10 @@ class MprisPlayer(IgnisGObject):
         Positive values move forward, and negative values move backward.
         The offset is in milliseconds.
         """
-        self.__player_proxy.Seek(
-            "(x)", offset * 1_000_100, result_handler=lambda *args: None
-        )
+        self.__player_proxy.Seek("(x)", offset * 1_000_100)
+
+    async def seek_async(self, offset: int) -> None:
+        """
+        Asynchronous version of :func:`seek`.
+        """
+        await self.__player_proxy.SeekAsync("(x)", offset * 1_000_100)

--- a/ignis/services/mpris/player.py
+++ b/ignis/services/mpris/player.py
@@ -365,6 +365,12 @@ class MprisPlayer(IgnisGObject):
         asyncio.create_task(self.__update_position())
 
     async def set_position_async(self, value: int) -> None:
+        """
+        Asynchronously set position.
+
+        Args:
+            value: The value to set.
+        """
         await self.__player_proxy.SetPositionAsync(
             "(ox)", self.track_id, value * 1_000_000
         )

--- a/ignis/services/system_tray/item.py
+++ b/ignis/services/system_tray/item.py
@@ -360,7 +360,6 @@ class SystemTrayItem(IgnisGObject):
         """
         Asynchronous version of :func:`context_menu`.
 
-
         Args:
             x: x coordinate.
             y: y coordinate.

--- a/ignis/services/system_tray/item.py
+++ b/ignis/services/system_tray/item.py
@@ -314,7 +314,17 @@ class SystemTrayItem(IgnisGObject):
             x: x coordinate.
             y: y coordinate.
         """
-        self.__dbus.Activate("(ii)", x, y, result_handler=lambda *args: None)
+        self.__dbus.Activate("(ii)", x, y)
+
+    async def activate_async(self, x: int = 0, y: int = 0) -> None:
+        """
+        Asynchronous version of :func:`activate`.
+
+        Args:
+            x: x coordinate.
+            y: y coordinate.
+        """
+        await self.__dbus.ActivateAsync("(ii)", x, y)
 
     def secondary_activate(self, x: int = 0, y: int = 0) -> None:
         """
@@ -324,7 +334,17 @@ class SystemTrayItem(IgnisGObject):
             x: x coordinate.
             y: y coordinate.
         """
-        self.__dbus.SecondaryActivate("(ii)", x, y, result_handler=lambda *args: None)
+        self.__dbus.SecondaryActivate("(ii)", x, y)
+
+    async def secondary_activate_async(self, x: int = 0, y: int = 0) -> None:
+        """
+        Asynchronous version of :func:`secondary_activate`.
+
+        Args:
+            x: x coordinate.
+            y: y coordinate.
+        """
+        await self.__dbus.SecondaryActivateAsync("(ii)", x, y)
 
     def context_menu(self, x: int = 0, y: int = 0) -> None:
         """
@@ -334,7 +354,18 @@ class SystemTrayItem(IgnisGObject):
             x: x coordinate.
             y: y coordinate.
         """
-        self.__dbus.ContextMenu("(ii)", x, y, result_handler=lambda *args: None)
+        self.__dbus.ContextMenu("(ii)", x, y)
+
+    async def context_menu_async(self, x: int = 0, y: int = 0) -> None:
+        """
+        Asynchronous version of :func:`context_menu`.
+
+
+        Args:
+            x: x coordinate.
+            y: y coordinate.
+        """
+        await self.__dbus.ContextMenuAsync("(ii)", x, y)
 
     def scroll(
         self,
@@ -348,6 +379,18 @@ class SystemTrayItem(IgnisGObject):
             delta: The amount of scroll.
             orientation: The type of the orientation: horizontal or vertical.
         """
-        self.__dbus.Scroll(
-            "(is)", delta, orientation, result_handler=lambda *args: None
-        )
+        self.__dbus.Scroll("(is)", delta, orientation)
+
+    async def scroll_async(
+        self,
+        delta: int = 0,
+        orientation: Literal["horizontal", "vertical"] = "horizontal",
+    ) -> None:
+        """
+        Asynchronous version of :func:`scroll`.
+
+        Args:
+            delta: The amount of scroll.
+            orientation: The type of the orientation: horizontal or vertical.
+        """
+        await self.__dbus.ScrollAsync("(is)", delta, orientation)

--- a/ignis/services/systemd/unit.py
+++ b/ignis/services/systemd/unit.py
@@ -72,7 +72,16 @@ class SystemdUnit(IgnisGObject):
             "(s)",
             "replace",
             flags=self._flags,
-            result_handler=self.__handle_result,
+        )
+
+    async def start_async(self) -> None:
+        """
+        Asynchronous version of :func:`start`.
+        """
+        await self._proxy.StartAsync(
+            "(s)",
+            "replace",
+            flags=self._flags,
         )
 
     def stop(self) -> None:
@@ -83,7 +92,16 @@ class SystemdUnit(IgnisGObject):
             "(s)",
             "replace",
             flags=self._flags,
-            result_handler=self.__handle_result,
+        )
+
+    async def stop_async(self) -> None:
+        """
+        Asynchronous version of :func:`stop`.
+        """
+        await self._proxy.StopAsync(
+            "(s)",
+            "replace",
+            flags=self._flags,
         )
 
     def restart(self) -> None:
@@ -94,5 +112,14 @@ class SystemdUnit(IgnisGObject):
             "(s)",
             "replace",
             flags=self._flags,
-            result_handler=self.__handle_result,
+        )
+
+    async def restart_async(self) -> None:
+        """
+        Asynchronous version of :func:`restart`.
+        """
+        await self._proxy.RestartAsync(
+            "(s)",
+            "replace",
+            flags=self._flags,
         )


### PR DESCRIPTION
Many services with public functions that call D-Bus methods did so asynchronously using ``result_handler *args: None``.
This made these functions asynchronous but did not allow passing a custom result handler, nor did it follow the async/await style.

This PR adds explicit async versions of these methods. The current ones are now synchronous.
Affected methods:
- ``MprisPlayer``
    - ``next()``
    - ``previous()``
    - ``pause()``
    - ``play()``
    - `play_pause()`
    - `stop()`
    - `seek()`

- `SystemTrayItem`
    - `activate()`
    - `secondary_activate()`
    - `context_menu()`
    - `scroll()`

- `SystemdUnit`
    - `start()`
    - `stop()`
    - `restart()`

This also affects some property setters:

``BacklightDevice.brightness`` setter is now synchronous, you can use its asynchronous version which is available as usual method: ``set_brightness_async()``. Same for ``BacklightService.brightness`` and ``MprisPlayer.position``.
