### PR TITLE
feat: store compiled css file in a random temporary directory

### DIFF
--- a/ignis/utils/sass.py
+++ b/ignis/utils/sass.py
@@ -1,12 +1,11 @@
-import os
 import shutil
 import subprocess
+import tempfile
 from typing import Literal
 from ignis.exceptions import SassCompilationError, SassNotFoundError
 
-TEMP_DIR = "/tmp/ignis"
+TEMP_DIR = tempfile.mkdtemp(prefix="ignis-")
 COMPILED_CSS = f"{TEMP_DIR}/compiled.css"
-os.makedirs(TEMP_DIR, exist_ok=True)
 
 # resolve Sass compiler paths and pick a default one
 # "sass" (dart-sass) is the default,


### PR DESCRIPTION
Avoid store the compiled CSS file in a hard-coded path.

This will prevent the file being overwritten when running multiple instances (https://github.com/linkfrg/ignis/issues/137).