### PR TITLE
fix(HyprlandService): parse event data correctly with multiple ">>"

### DIFF
--- a/ignis/services/hyprland/service.py
+++ b/ignis/services/hyprland/service.py
@@ -189,9 +189,8 @@ class HyprlandService(BaseService):
         def get_full_w_addr(addr: str) -> str:
             return "0x" + addr
 
-        event_data = event.split(">>")
-        event_type = event_data[0]
-        event_value = event_data[1]
+        event_data = event.split(">>", 1)
+        event_type, event_value = event_data
         value_list = event_value.split(",")
 
         match event_type:


### PR DESCRIPTION
Parse `event_data` into pair, in case `event_value` containing `>>`.