### PR TITLE
fix!(`HyprlandService`): rename method to match return type

### DIFF
--- a/ignis/services/hyprland/service.py
+++ b/ignis/services/hyprland/service.py
@@ -449,7 +449,7 @@ class HyprlandService(BaseService):
         """
         return self._windows.get(address, None)
 
-    def get_monitor_name(self, name: str) -> HyprlandMonitor | None:
+    def get_monitor_by_name(self, name: str) -> HyprlandMonitor | None:
         """
         Get a monitor by its name.
 


### PR DESCRIPTION
`get_monitor_name` -> `get_monitor_by_name`