### PR TITLE
feat!: store options in `XDG_DATA_HOME`

### DIFF
--- a/ignis/__init__.py
+++ b/ignis/__init__.py
@@ -37,6 +37,9 @@ TEMP_DIR = tempfile.mkdtemp(prefix="ignis-")
 #: The cache directory. Equals ``$XDG_CACHE_HOME/ignis`` by default, or :obj:`TEMP_DIR` during the Sphinx doc build.
 CACHE_DIR = f"{GLib.get_user_cache_dir()}/ignis" if not is_sphinx_build else TEMP_DIR
 
+#: The data directory. Equals ``$XDG_DATA_HOME/ignis`` by default, or :obj:`TEMP_DIR` during the Sphinx doc build.
+DATA_DIR = f"{GLib.get_user_data_dir()}/ignis" if not is_sphinx_build else TEMP_DIR
+
 #: Whether libgirepository-2.0 is being used (``True`` for PyGObject 3.51.0 and higher).
 #: Always equals ``False`` during the Sphinx doc build.
 is_girepository_2_0: bool = (
@@ -73,6 +76,7 @@ def _init_asyncio() -> None:
 
 def _makedirs() -> None:
     os.makedirs(CACHE_DIR, exist_ok=True)
+    os.makedirs(DATA_DIR, exist_ok=True)
 
 
 def _load_gtk_layer_shell() -> None:

--- a/ignis/options.py
+++ b/ignis/options.py
@@ -62,7 +62,7 @@ class Options(OptionsManager):
         If the option is of type :class:`~ignis.options_manager.TrackedList`, it means that it is regular Python list.
         But you can call ``.append()``, ``.remove()``, ``.insert()``, etc., and the changes will be applied!
 
-    The options file is stored in :obj:`ignis.DATA_DIR`/options.json (``$XDG_DATA_HOME/ignis/options.json``)
+    The options file is located at :obj:`ignis.DATA_DIR`/options.json (``$XDG_DATA_HOME/ignis/options.json``).
 
     Example usage:
 

--- a/ignis/options.py
+++ b/ignis/options.py
@@ -1,7 +1,12 @@
-from ignis import CACHE_DIR
+import os
+from ignis import DATA_DIR, CACHE_DIR, is_sphinx_build
 from gi.repository import GLib  # type: ignore
 from ignis.options_manager import OptionsManager, OptionsGroup, TrackedList
-from ignis import is_sphinx_build
+from loguru import logger
+
+
+OPTIONS_FILE = f"{DATA_DIR}/options.json"
+OLD_OPTIONS_FILE = f"{CACHE_DIR}/ignis_options.json"
 
 
 def get_recorder_default_file_location() -> str | None:
@@ -9,6 +14,21 @@ def get_recorder_default_file_location() -> str | None:
         return GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_VIDEOS)
     else:
         return "XDG Videos directory"
+
+
+# FIXME: remove after v0.6 release
+def _migrate_old_options_file() -> None:
+    logger.warning(
+        f"Migrating options to the new file: {OLD_OPTIONS_FILE} -> {OPTIONS_FILE}"
+    )
+    with open(OLD_OPTIONS_FILE) as f:
+        data = f.read()
+
+    with open(OPTIONS_FILE, "w") as f:
+        f.write(data)
+    logger.success(
+        f"Done. Consider using new options file instead: $XDG_DATA_HOME/ignis/options.json ({OPTIONS_FILE}). The old one is deprecated. See the Breaking Changes Tracker for more info."
+    )
 
 
 class Options(OptionsManager):
@@ -40,6 +60,8 @@ class Options(OptionsManager):
         If the option is of type :class:`~ignis.options_manager.TrackedList`, it means that it is regular Python list.
         But you can call ``.append()``, ``.remove()``, ``.insert()``, etc., and the changes will be applied!
 
+    The options file is stored in :obj:`ignis.DATA_DIR`/options.json (``$XDG_DATA_HOME/ignis/options.json``)
+
     Example usage:
 
     .. code-block::
@@ -66,8 +88,11 @@ class Options(OptionsManager):
         if is_sphinx_build:
             return
 
+        if not os.path.exists(OPTIONS_FILE) and os.path.exists(OLD_OPTIONS_FILE):
+            _migrate_old_options_file()
+
         try:
-            super().__init__(file=f"{CACHE_DIR}/ignis_options.json")
+            super().__init__(file=OPTIONS_FILE)
         except FileNotFoundError:
             pass
 

--- a/ignis/options.py
+++ b/ignis/options.py
@@ -21,11 +21,13 @@ def _migrate_old_options_file() -> None:
     logger.warning(
         f"Migrating options to the new file: {OLD_OPTIONS_FILE} -> {OPTIONS_FILE}"
     )
+
     with open(OLD_OPTIONS_FILE) as f:
         data = f.read()
 
     with open(OPTIONS_FILE, "w") as f:
         f.write(data)
+
     logger.success(
         f"Done. Consider using new options file instead: $XDG_DATA_HOME/ignis/options.json ({OPTIONS_FILE}). The old one is deprecated. See the Breaking Changes Tracker for more info."
     )

--- a/ignis/options_manager.py
+++ b/ignis/options_manager.py
@@ -302,6 +302,9 @@ class OptionsManager(OptionsGroup):
         file: The path to the file used for saving and loading options. Cannot be changed after initialization.
         hot_reload: Whether to enable hot-reloading.
 
+    .. hint::
+        The recommended directory for storing the options file is :obj:`ignis.DATA_DIR`.
+
     The standard option structure must follow this format:
 
     .. code-block:: python


### PR DESCRIPTION
This PR makes `Options` to store its data in `$XDG_DATA_HOME/ignis/options.json` (`$HOME/.local/share/ignis/options.json`) instead of `$XDG_CACHE_HOME/ignis/ignis_options.json`.
Also it adds `ignis.DATA_DIR` variable.
This change will protect options from being removed when the user clears cache.
`Options` will automatically migrate your options from the old file to the new one.

Consider migrating your user options (if you use them) to the new directory (e.g., `f"{DATA_DIR}/user_options.json"`.