### PR TITLE
feat: deprecate `Utils` for pythonic `utils`

### DIFF
--- a/ignis/deprecation.py
+++ b/ignis/deprecation.py
@@ -4,6 +4,9 @@ from loguru import logger
 from collections.abc import Callable
 
 
+logger.level("DEPRECATED", no=25)
+
+
 def deprecation_warning(message: str) -> None:
     """
     Log a warning about the deprecation of a feature or function.

--- a/ignis/logging.py
+++ b/ignis/logging.py
@@ -70,4 +70,4 @@ def configure_logger(debug: bool) -> None:
 
     GLib.log_set_writer_func(g_log_writer)
 
-    logger.level("DEPRECATED", no=25, color="<yellow>")
+    logger.level("DEPRECATED", color="<yellow>")

--- a/ignis/utils/__init__.py
+++ b/ignis/utils/__init__.py
@@ -1,4 +1,5 @@
 from typing import TypeAlias
+from ignis.deprecation import deprecated_class
 from .debounce import DebounceTask, debounce
 from .file_monitor import FileMonitor
 from .file import read_file, read_file_async, write_file, write_file_async
@@ -21,6 +22,7 @@ from .version import (
 )
 
 
+@deprecated_class("`Utils` class is deprecated, use `from ignis import utils` instead.")
 class Utils:
     exec_sh = exec_sh
     exec_sh_async = exec_sh_async
@@ -56,3 +58,42 @@ class Utils:
     write_file = write_file
     write_file_async = write_file_async
     get_app_icon_name = get_app_icon_name
+
+
+__all__ = [
+    "AsyncCompletedProcess",
+    "crop_pixbuf",
+    "debounce",
+    "DebounceTask",
+    "exec_sh",
+    "exec_sh_async",
+    "FileMonitor",
+    "get_app_icon_name",
+    "get_current_dir",
+    "get_file_icon_name",
+    "get_ignis_branch",
+    "get_ignis_commit",
+    "get_ignis_commit_msg",
+    "get_ignis_version",
+    "get_monitor",
+    "get_monitors",
+    "get_n_monitors",
+    "get_paintable",
+    "listen_socket",
+    "load_interface_xml",
+    "pascal_to_snake",
+    "Poll",
+    "read_file",
+    "read_file_async",
+    "run_in_thread",
+    "sass_compile",
+    "scale_pixbuf",
+    "send_socket",
+    "snake_to_pascal",
+    "thread",
+    "ThreadTask",
+    "Timeout",
+    "Utils",
+    "write_file",
+    "write_file_async",
+]


### PR DESCRIPTION
Continue the same theme as https://github.com/linkfrg/ignis/pull/226

Add the logger level in module level to avoid

```
ValueError: Level 'DEPRECATED' does not exist
```