### PR TITLE
fix(nix): use os.execv for reload (#268)

### DIFF
--- a/ignis/app.py
+++ b/ignis/app.py
@@ -36,12 +36,6 @@ def raise_css_parsing_error(
     raise CssParsingError(section, gerror)
 
 
-def _is_elf_file(path: str) -> bool:
-    with open(path, "rb") as f:
-        magic = f.read(4)
-        return magic == b"\x7fELF"
-
-
 @dataclass
 class _CssProviderInfo:
     provider: Gtk.CssProvider
@@ -530,14 +524,7 @@ class IgnisApp(Gtk.Application, IgnisGObject):
         Reload Ignis.
         """
         self.quit()
-
-        # https://github.com/linkfrg/ignis/issues/267
-        # Nix wraps the Ignis executable, so bin/ignis is not python file anymore, but a binary file (ELF)
-        # So, we launch this binary directly (it's always the first in sys.argv)
-        if _is_elf_file(sys.argv[0]):
-            os.execl(sys.argv[0], sys.argv[0], *sys.argv[1:])
-        else:
-            os.execl(sys.executable, sys.executable, *sys.argv)
+        os.execv(sys.argv[0], sys.argv)
 
     def quit(self) -> None:
         """


### PR DESCRIPTION
Replaced `os.execl` with `os.execv` to avoid the additional check for whether the file is a binary (ELF).
I tested the reload functionality in NixOS, and everything works:  
```console
ignis init && ignis reload
```  
Unfortunately, I currently don't have the ability to test this fix on other distributions or in more complex restart scenarios.  
If `os.execv` cannot be used for some reason, feel free to close this PR.  
