### PR TITLE
feat!(cli): move to `typer`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,6 +20,7 @@ extensions = [
     "sphinx_design",
     "sphinx_copybutton",
     "sphinx_autodoc_typehints",
+    'sphinxcontrib.typer',
     "_ext.ignis_directives",
 ]
 
@@ -40,7 +41,7 @@ suppress_warnings = ["config.cache"]
 
 # ============================ AUTODOC/TYPEHINTS ============================
 
-autodoc_mock_imports = ["gi", "loguru", "setuptools", "click", "cairo"]
+autodoc_mock_imports = ["gi", "loguru", "setuptools", "typer", "cairo"]
 autodoc_member_order = "bysource"
 
 smartquotes = False

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,4 @@ pydata-sphinx-theme>=0.15.4
 sphinx_design>=0.6.1
 sphinx_copybutton>=0.5.2
 sphinx-autodoc-typehints>=2.5.0
+sphinxcontrib-typer>=0.5.1

--- a/docs/user/cli.rst
+++ b/docs/user/cli.rst
@@ -1,26 +1,11 @@
 CLI
 ==============
 
-I'm too lazy to describe everything in detail, so here's a help message for you
+Run ``ignis --help`` to get the help message for CLI usage.
 
-.. code-block:: bash
-
-    $ ignis --help
-
-    Usage: ignis [OPTIONS] COMMAND [ARGS]...
-
-    Options:
-    --version  Print version and exit
-    --help     Show this message and exit.
-
-    Commands:
-    init          Initialize Ignis
-    open          Open window
-    close         Close window
-    toggle        Toggle window
-    list-windows  List all windows
-    run-python    Execute python code
-    run-file      Execute python file
-    inspector     Open GTK Inspector
-    reload        Reload Ignis
-    quit          Quit Ignis
+.. typer:: ignis.cli.cli_app
+    :prog: ignis
+    :width: 80
+    :preferred: svg
+    :show-nested:
+    :make-sections:

--- a/docs/user/cli.rst
+++ b/docs/user/cli.rst
@@ -1,7 +1,7 @@
 CLI
 ==============
 
-Run ``ignis --help`` to get the help message for CLI usage.
+Run ``ignis --help`` to view the CLI usage help message.
 
 .. typer:: ignis.cli.cli_app
     :prog: ignis

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -67,7 +67,7 @@ Building from source
 - glib-mkenums (glib2-devel)
 - pygobject >= 3.50.0
 - pycairo
-- python-click
+- python-typer
 - python-loguru
 - libpulse (if using PipeWire, install ``pipewire-pulse``)
 

--- a/ignis/cli.py
+++ b/ignis/cli.py
@@ -5,12 +5,15 @@ from ignis.client import IgnisClient
 from ignis.utils import Utils
 from ignis.exceptions import WindowNotFoundError
 from typing import Any
-from gi.repository import GLib  # type: ignore
-from ignis import is_editable_install
+from ignis import is_editable_install, is_sphinx_build
 from typing import Annotated
 
+if is_sphinx_build:
+    DEFAULT_CONFIG_PATH = "$HOME/.config/ignis/config.py"
+else:
+    from gi.repository import GLib  # type: ignore
 
-DEFAULT_CONFIG_PATH = f"{GLib.get_user_config_dir()}/ignis/config.py"
+    DEFAULT_CONFIG_PATH = f"{GLib.get_user_config_dir()}/ignis/config.py"
 
 
 cli_app = typer.Typer(

--- a/ignis/cli.py
+++ b/ignis/cli.py
@@ -90,7 +90,7 @@ def get_full_path(path: str) -> str:
     return os.path.abspath(os.path.expanduser(path))
 
 
-def version_callback(value: bool):
+def version_callback(value: bool) -> None:
     if value:
         typer.echo(get_version_message())
         raise typer.Exit()
@@ -107,7 +107,7 @@ def main_callback(
             help="Print version and exit.",
         ),
     ] = None,
-):
+) -> None:
     return
 
 

--- a/ignis/cli.py
+++ b/ignis/cli.py
@@ -8,6 +8,9 @@ from typing import Any
 from ignis import is_editable_install, is_sphinx_build
 from typing import Annotated
 
+# Do not import gi.repository during sphinx build
+# Otherwise, ignis.cli package will be unavailable:
+# ``AttributeError: module 'ignis' has no attribute 'cli' [docutils]``
 if is_sphinx_build:
     DEFAULT_CONFIG_PATH = ""  # not used during sphinx build, just set to empty string
 else:

--- a/ignis/cli.py
+++ b/ignis/cli.py
@@ -201,7 +201,7 @@ def run_file(
     """
     Execute a Python file inside the running Ignis process.
     """
-    call_client_func("run_python", get_full_path(file))
+    call_client_func("run_file", get_full_path(file))
 
 
 @cli_app.command()

--- a/ignis/cli.py
+++ b/ignis/cli.py
@@ -9,7 +9,7 @@ from ignis import is_editable_install, is_sphinx_build
 from typing import Annotated
 
 if is_sphinx_build:
-    DEFAULT_CONFIG_PATH = "$HOME/.config/ignis/config.py"
+    DEFAULT_CONFIG_PATH = ""  # not used during sphinx build, just set to empty string
 else:
     from gi.repository import GLib  # type: ignore
 
@@ -111,10 +111,15 @@ def main_callback(
 @cli_app.command()
 def init(
     config: Annotated[
-        str, typer.Option(help="Path to the configuration file", metavar="PATH")
+        str,
+        typer.Option(
+            help="Path to the configuration file.",
+            metavar="PATH",
+            show_default="~/.config/ignis/config.py",
+        ),
     ] = DEFAULT_CONFIG_PATH,
     debug: Annotated[
-        bool, typer.Option(help="Print debug information to terminal")
+        bool, typer.Option(help="Print debug information to terminal.")
     ] = False,
 ) -> None:
     """
@@ -132,8 +137,16 @@ def init(
     run_app(config_path, debug)
 
 
+WindowArgument = Annotated[
+    str,
+    typer.Argument(
+        help="The name of the window.", metavar="WINDOW_NAME", show_default=False
+    ),
+]
+
+
 @cli_app.command()
-def open_window(window: str) -> None:
+def open_window(window: WindowArgument) -> None:
     """
     Open a window.
     """
@@ -141,7 +154,7 @@ def open_window(window: str) -> None:
 
 
 @cli_app.command()
-def close_window(window: str) -> None:
+def close_window(window: WindowArgument) -> None:
     """
     Close a window.
     """
@@ -149,7 +162,7 @@ def close_window(window: str) -> None:
 
 
 @cli_app.command()
-def toggle_window(window: str) -> None:
+def toggle_window(window: WindowArgument) -> None:
     """
     Toggle a window.
     """
@@ -159,14 +172,19 @@ def toggle_window(window: str) -> None:
 @cli_app.command()
 def list_windows() -> None:
     """
-    List names of all window.
+    List names of all windows.
     """
     window_list = call_client_func("list_windows")
     print("\n".join(window_list))
 
 
 @cli_app.command()
-def run_python(code: str) -> None:
+def run_python(
+    code: Annotated[
+        str,
+        typer.Argument(help="The code to execute.", metavar="CODE", show_default=False),
+    ],
+) -> None:
     """
     Execute a Python code inside the running Ignis process.
     """
@@ -174,7 +192,12 @@ def run_python(code: str) -> None:
 
 
 @cli_app.command()
-def run_file(file: str) -> None:
+def run_file(
+    file: Annotated[
+        str,
+        typer.Argument(help="The file to execute.", metavar="PATH", show_default=False),
+    ],
+) -> None:
     """
     Execute a Python file inside the running Ignis process.
     """

--- a/ignis/cli.py
+++ b/ignis/cli.py
@@ -1,24 +1,23 @@
 import os
-import click
+import typer
 import subprocess
-import collections
 from ignis.client import IgnisClient
 from ignis.utils import Utils
 from ignis.exceptions import WindowNotFoundError
 from typing import Any
 from gi.repository import GLib  # type: ignore
 from ignis import is_editable_install
+from typing import Annotated
+
 
 DEFAULT_CONFIG_PATH = f"{GLib.get_user_config_dir()}/ignis/config.py"
 
 
-class OrderedGroup(click.Group):
-    def __init__(self, name=None, commands=None, **attrs):
-        super().__init__(name, commands, **attrs)
-        self.commands = commands or collections.OrderedDict()
-
-    def list_commands(self, ctx):
-        return self.commands
+cli_app = typer.Typer(
+    name="ignis",
+    help="A widget framework for building desktop shells, written and configurable in Python.",
+    no_args_is_help=True,
+)
 
 
 def _run_git_cmd(args: str) -> str | None:
@@ -68,11 +67,6 @@ os-release:
 {os_release}"""
 
 
-def print_version(ctx, param, value):
-    if value:
-        ctx.exit(print(get_version_message()))
-
-
 def call_client_func(name: str, *args) -> Any:
     client = IgnisClient()
     if not client.has_owner:
@@ -90,30 +84,39 @@ def get_full_path(path: str) -> str:
     return os.path.abspath(os.path.expanduser(path))
 
 
-@click.group(cls=OrderedGroup)
-@click.option(
-    "--version",
-    is_flag=True,
-    callback=print_version,
-    expose_value=False,
-    is_eager=True,
-    help="Print version and exit",
-)
-def cli():
-    pass
+def version_callback(value: bool):
+    if value:
+        typer.echo(get_version_message())
+        raise typer.Exit()
 
 
-@cli.command(name="init", help="Initialize Ignis")
-@click.option(
-    "--config",
-    "-c",
-    help=f"Path to the configuration file (default: {DEFAULT_CONFIG_PATH})",
-    default=DEFAULT_CONFIG_PATH,
-    type=str,
-    metavar="PATH",
-)
-@click.option("--debug", help="Print debug information to terminal", is_flag=True)
-def init(config: str, debug: bool) -> None:
+@cli_app.callback()
+def main_callback(
+    version: Annotated[
+        bool | None,
+        typer.Option(
+            "--version",
+            callback=version_callback,
+            is_eager=True,
+            help="Print version and exit.",
+        ),
+    ] = None,
+):
+    return
+
+
+@cli_app.command()
+def init(
+    config: Annotated[
+        str, typer.Option(help="Path to the configuration file", metavar="PATH")
+    ] = DEFAULT_CONFIG_PATH,
+    debug: Annotated[
+        bool, typer.Option(help="Print debug information to terminal")
+    ] = False,
+) -> None:
+    """
+    Initialize Ignis.
+    """
     from ignis.app import run_app
 
     client = IgnisClient()
@@ -126,57 +129,82 @@ def init(config: str, debug: bool) -> None:
     run_app(config_path, debug)
 
 
-@cli.command(name="open", help="Open window")
-@click.argument("window")
+@cli_app.command()
 def open_window(window: str) -> None:
+    """
+    Open a window.
+    """
     call_client_func("open_window", window)
 
 
-@cli.command(name="close", help="Close window")
-@click.argument("window")
-def close(window: str) -> None:
+@cli_app.command()
+def close_window(window: str) -> None:
+    """
+    Close a window.
+    """
     call_client_func("close_window", window)
 
 
-@cli.command(name="toggle", help="Toggle window")
-@click.argument("window")
-def toggle(window: str) -> None:
-    call_client_func("toggle_window", window)
+@cli_app.command()
+def toggle_window(window: str) -> None:
+    """
+    Toggle a window.
+    """
+    call_client_func("open_window", window)
 
 
-@cli.command(name="list-windows", help="List all windows")
+@cli_app.command()
 def list_windows() -> None:
+    """
+    List names of all window.
+    """
     window_list = call_client_func("list_windows")
     print("\n".join(window_list))
 
 
-@cli.command(name="run-python", help="Execute python code")
-@click.argument("code")
+@cli_app.command()
 def run_python(code: str) -> None:
+    """
+    Execute a Python code inside the running Ignis process.
+    """
     call_client_func("run_python", code)
 
 
-@cli.command(name="run-file", help="Execute python file")
-@click.argument("file")
+@cli_app.command()
 def run_file(file: str) -> None:
-    call_client_func("run_file", get_full_path(file))
+    """
+    Execute a Python file inside the running Ignis process.
+    """
+    call_client_func("run_python", get_full_path(file))
 
 
-@cli.command(name="inspector", help="Open GTK Inspector")
+@cli_app.command()
 def inspector() -> None:
+    """
+    Open GTK Inspector.
+    """
     call_client_func("inspector")
 
 
-@cli.command(name="reload", help="Reload Ignis")
+@cli_app.command()
 def reload() -> None:
+    """
+    Reload Ignis.
+    """
     call_client_func("reload")
 
 
-@cli.command(name="quit", help="Quit Ignis")
+@cli_app.command()
 def quit() -> None:
+    """
+    Quit Ignis.
+    """
     call_client_func("quit")
 
 
-@cli.command(name="systeminfo", help="Print system information")
+@cli_app.command()
 def systeminfo() -> None:
+    """
+    Print system information.
+    """
     print(get_systeminfo())

--- a/ignis/cli.py
+++ b/ignis/cli.py
@@ -169,7 +169,7 @@ def toggle_window(window: WindowArgument) -> None:
     """
     Toggle a window.
     """
-    call_client_func("open_window", window)
+    call_client_func("toggle_window", window)
 
 
 @cli_app.command()

--- a/ignis/main.py
+++ b/ignis/main.py
@@ -1,5 +1,5 @@
 import ctypes
-from ignis.cli import cli
+from ignis.cli import cli_app
 
 
 def set_process_name(name):
@@ -9,7 +9,7 @@ def set_process_name(name):
 
 def main():
     set_process_name("ignis")
-    cli(prog_name="ignis")
+    cli_app(prog_name="ignis")
 
 
 if __name__ == "__main__":

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -30,7 +30,7 @@
       buildPythonPackage
       pygobject3
       pycairo
-      click
+      typer
       loguru
     ;
     inherit (gst_all_1)
@@ -76,7 +76,7 @@
 
     pygobject3
     pycairo
-    click
+    typer
     loguru
   ];
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [{ name = 'linkfrg' }]
 dynamic = ['version']
 requires-python = ">=3.11"
 dependencies = [
-    "click>=8.1.7",
+    "typer>=0.15.2",
     "pycairo>=1.26.1",
     "PyGObject>=3.50.0",
     "loguru>=0.7.2",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-click>=8.1.7
+typer>=0.15.2
 pycairo>=1.26.1
 PyGObject>=3.50.0
 loguru>=0.7.2


### PR DESCRIPTION
This PR moves CLI to using `typer` instead of `click`.
`typer` is nicer to use, provides a more beautiful help messages and has built-in completion support.

Also, it improves the CLI page in docs by making it autogenerated via [sphinxcontrib-typer](https://github.com/sphinx-contrib/typer) and adding description for each command.

## Breaking Changes

- **Some commands were renamed in order to provide a more appropriate name:**
  - `open` -> `open-window`
  - `close` -> `close-window`
  - `toggle` -> `toggle-window`

- **Ignis requires `typer` instead of `click` now**