### PR TITLE
fix niri 25.05 socket

### DIFF
--- a/ignis/utils/socket.py
+++ b/ignis/utils/socket.py
@@ -23,7 +23,10 @@ def send_socket(
     resp = sock.recv(8192)
 
     while True:
-        new_data = sock.recv(8192)
+        try:
+            new_data = sock.recv(8192, socket.MSG_DONTWAIT)
+        except BlockingIOError:
+            break
         if not new_data:
             break
         resp += new_data


### PR DESCRIPTION
Niri 25.05 seems to have changed something in the IPC. Unfortunately I can't find niri's documentation of this.

So the second `recv` (first one in while) blocks indefinitely.

Don't know if this is the best way to fix it. Last byte in niri's message is `\n` (right after closing last json's `}`), this could be another way to check if whole message is received.