### PR TITLE
fix(NiriService): adapt event stream initialization to new IPC event

### DIFF
--- a/ignis/services/niri/service.py
+++ b/ignis/services/niri/service.py
@@ -123,10 +123,10 @@ class NiriService(BaseService):
         app.connect("shutdown", lambda *_: sock.close())
 
         # Launch an unthreaded event stream to ensure all variables get initialized
-        # before returning from __init__ . KeyboardLayoutsChanged is always the last
+        # before returning from __init__ . OverviewOpenedOrClosed is the last
         # event to be sent during initialization of the Niri event stream, so once
         # it is received, we are ready to launch a threaded (non blocking) version.
-        self.__listen_events(sock=sock, break_on="KeyboardLayoutsChanged")
+        self.__listen_events(sock=sock, break_on="OverviewOpenedOrClosed")
 
         Utils.thread(lambda: self.__listen_events(sock=sock))
         # No need to send any other commands after event stream initialization:


### PR DESCRIPTION
Since https://github.com/linkfrg/ignis/pull/289, `OverviewOpenedOrClosed` is now the last event to be sent during initialization of Niri's event stream.