### PR TITLE
fix: prepend gvc lib64 dir path

### DIFF
--- a/ignis/__init__.py
+++ b/ignis/__init__.py
@@ -134,7 +134,6 @@ def _prepend_gvc() -> None:
     for directory in _GVC_LIB_DIR_PATHS:
         if os.path.exists(directory):
             _prepend_to_repo(path=directory)
-        return
 
 
 def _init() -> None:


### PR DESCRIPTION
This fixes #440 by checking both /usr/lib and /usr/lib64 paths