### PR TITLE
[feature] Add and show the transient hint on notifications

### DIFF
--- a/ignis/services/notifications/notification.py
+++ b/ignis/services/notifications/notification.py
@@ -23,6 +23,7 @@ class Notification(IgnisGObject):
         timeout: int,
         time: float,
         popup: bool,
+        transient: bool,
     ):
         super().__init__()
 
@@ -36,6 +37,7 @@ class Notification(IgnisGObject):
         self._time = time
         self._urgency = urgency
         self._popup = popup
+        self._transient = transient
         self._actions = [
             NotificationAction(
                 id=str(actions[i]),
@@ -136,6 +138,13 @@ class Notification(IgnisGObject):
         Whether the notification is a popup.
         """
         return self._popup
+
+    @IgnisProperty
+    def transient(self) -> bool:
+        """
+        Whether the notification is transient (ignored in any notification center implementation).
+        """
+        return self._transient
 
     @IgnisProperty
     def json(self) -> dict:

--- a/ignis/services/notifications/service.py
+++ b/ignis/services/notifications/service.py
@@ -220,6 +220,7 @@ class NotificationService(BaseService):
             timeout=options.notifications.popup_timeout if timeout == -1 else timeout,
             time=datetime.now().timestamp(),
             popup=not options.notifications.dnd,
+            transient=hints.get("transient", False),
         )
 
         if len(self.popups) >= options.notifications.max_popups_count:


### PR DESCRIPTION
See: https://specifications.freedesktop.org/notification/latest/hints.html

The `transient` hint is used on notifications to mark them as *just* pop-ups and they are gone after the timeout.  When set to false (the default) the pop-ups should be shown in history/notification-center style displays.  This is used for things like music players that pop-up the now-playing or things like volume level pop-ups so that they don't clutter the history.