### PR TITLE
[bugfix][hyprland] Expose way to update hyprland keyboard

### DIFF
--- a/ignis/services/hyprland/service.py
+++ b/ignis/services/hyprland/service.py
@@ -354,6 +354,12 @@ class HyprlandService(BaseService):
 
         self.notify("main-keyboard")
 
+    def update_main_keyboard(self) -> None:
+        """
+        Update the `main_keyboard` property for the service (there is no passive/reactive way to do this).
+        """
+        self.__sync_main_keyboard()
+
     def __sync_active_layout(self, layout: str) -> None:
         self._main_keyboard.sync({"active_keymap": layout})
 


### PR DESCRIPTION
There is no event to respond to from hyprland to update the `main_keyboard` property.  This means that the `hyprland.main_keyboard` property is populated at start and *never* updated after.  This just exposes the proactive population method to be called if desired, via something like a `utils.Poll` if you want to hook something into it (like a caps-lock indicator).