### PR TITLE
feat:mpris Add the mpris bus-name as property

### DIFF
--- a/ignis/services/mpris/player.py
+++ b/ignis/services/mpris/player.py
@@ -15,9 +15,10 @@ class MprisPlayer(IgnisGObject):
     A media player object.
     """
 
-    def __init__(self, mpris_proxy: DBusProxy, player_proxy: DBusProxy):
+    def __init__(self, name: str, mpris_proxy: DBusProxy, player_proxy: DBusProxy):
         super().__init__()
 
+        self.name = name
         self.__mpris_proxy = mpris_proxy
         self.__player_proxy = player_proxy
         self._conn_mgr = ConnectionManager()
@@ -79,7 +80,7 @@ class MprisPlayer(IgnisGObject):
             info=utils.load_interface_xml("org.mpris.MediaPlayer2.Player"),
         )
 
-        obj = cls(mpris_proxy=mpris_proxy, player_proxy=player_proxy)
+        obj = cls(name=name, mpris_proxy=mpris_proxy, player_proxy=player_proxy)
         await obj._initial_sync()
         return obj
 


### PR DESCRIPTION
Feature I like to implement in my mpris monitor is syncing the last used and still existing mpris name to `/run/$UID/mpris_last_active` so that media keybinds can use `playerctl` for simple controls on the last player used (ex. stopping spotify to play a youtube video, then after the video is done, spotify would be the last available and the next media control should route there).