### PR TITLE
bugfix: properly separate multiple artists

### DIFF
--- a/ignis/services/mpris/player.py
+++ b/ignis/services/mpris/player.py
@@ -153,7 +153,7 @@ class MprisPlayer(IgnisGObject):
         self.__sync_metadata_property(
             "xesam:artist",
             "artist",
-            lambda artist: "".join(artist) if isinstance(artist, list) else artist,
+            lambda artist: ", ".join(artist) if isinstance(artist, list) else artist,
         )
         self.__sync_metadata_property("xesam:title", "title")
         self.__sync_metadata_property("xesam:url", "url")


### PR DESCRIPTION
Rather than have `artists` be `Dr. DreSnoop Dogg`, join with commas to give *some* level of delineation.