### PR TITLE
Hyprland Lua dispatch syntax

### DIFF
--- a/examples/bar/config.py
+++ b/examples/bar/config.py
@@ -65,7 +65,7 @@ def workspace_button(workspace) -> widgets.Button:
 
 
 def hyprland_scroll_workspaces(direction: str) -> None:
-    current = hyprland.active_workspace["id"]
+    current = hyprland.active_workspace.id
     if direction == "up":
         target = current - 1
         hyprland.switch_to_workspace(target)
@@ -299,7 +299,10 @@ def create_exec_task(cmd: str) -> None:
 
 def logout() -> None:
     if hyprland.is_available:
-        create_exec_task("hyprctl dispatch exit 0")
+        if hyprland.uses_lua_config:
+            create_exec_task("hyprctl dispatch 'hl.dsp.exit(0)'")
+        else:
+            create_exec_task("hyprctl dispatch exit 0")
     elif niri.is_available:
         create_exec_task("niri msg action quit")
     else:

--- a/ignis/services/hyprland/service.py
+++ b/ignis/services/hyprland/service.py
@@ -92,7 +92,10 @@ class HyprlandService(BaseService):
             ),
         }
 
+        self._uses_lua_config: bool = False
+
         if self.is_available:
+            self._uses_lua_config = self.__detect_lua_config()
             self.__listen_events()
 
             self.__initial_sync_obj_list(type_="workspace")
@@ -135,6 +138,13 @@ class HyprlandService(BaseService):
         Whether Hyprland IPC is available.
         """
         return os.path.exists(HYPR_SOCKET_DIR)
+
+    @IgnisProperty
+    def uses_lua_config(self) -> bool:
+        """
+        Whether Hyprland is using a Lua config.
+        """
+        return self._uses_lua_config
 
     @IgnisProperty
     def workspaces(self) -> list[HyprlandWorkspace]:
@@ -438,6 +448,13 @@ class HyprlandService(BaseService):
             data={"specialWorkspace": {"id": workspace_id, "name": workspace_name}},
         )
 
+    def __detect_lua_config(self) -> bool:
+        status = self.send_command("status")
+        for line in status.splitlines():
+            if line.startswith("configProvider:"):
+                return line.split(":", 1)[1].strip() == "lua"
+        return False
+
     def send_command(self, cmd: str) -> str:
         """
         Send a command to the Hyprland IPC.
@@ -467,7 +484,10 @@ class HyprlandService(BaseService):
         Args:
             workspace_id: The ID of the workspace to switch to.
         """
-        self.send_command(f"dispatch workspace {workspace_id}")
+        if self._uses_lua_config:
+            self.send_command(f"dispatch hl.dsp.focus({{workspace = {workspace_id}}})")
+        else:
+            self.send_command(f"dispatch workspace {workspace_id}")
 
     def get_workspace_by_id(self, workspace_id: int) -> HyprlandWorkspace | None:
         """

--- a/ignis/services/hyprland/workspace.py
+++ b/ignis/services/hyprland/workspace.py
@@ -100,4 +100,4 @@ class HyprlandWorkspace(DataGObject):
         """
         Switch to this workspace.
         """
-        self.__service.send_command(f"dispatch workspace {self.id}")
+        self.__service.switch_to_workspace(self.id)


### PR DESCRIPTION
As of version 0.55 Hyprland added lua configuration option. When using it, hyprctl dispatch calls expect Lua API [link](https://github.com/hyprwm/Hyprland/discussions/14255). This PR adds check for what config provider is used and uses proper syntax.